### PR TITLE
Config and backend improvements

### DIFF
--- a/src/EVTUI/App.axaml.cs
+++ b/src/EVTUI/App.axaml.cs
@@ -18,6 +18,9 @@ public partial class App : Application
     {
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
+            // TODO: if dataManager.ProjectManager.UserData is null...
+            // ...then the formatting is bad and we should check
+            // if the user want to start fresh or exit the program
             DataManager         dataManager     = new DataManager();
             MainWindowViewModel mainWindowVM    = new MainWindowViewModel(dataManager);
             MainWindow          mainWindow      = new MainWindow { DataContext = mainWindowVM };

--- a/src/EVTUI/Core/AudioManager.cs
+++ b/src/EVTUI/Core/AudioManager.cs
@@ -76,35 +76,38 @@ public class AudioManager
         this.AcbList.Clear();
         foreach (string key in this.AcbByType.Keys)
             this.AcbByType[key].Clear();
-        object _lock = new();
-        Parallel.ForEach(acwbPaths, acwbPath =>
+        if (!(acwbPaths is null))
         {
-            ACB soundFile = new ACB(acwbPath.ACB, eventCues, acwbPath.AWB);
-            if (!(soundFile.Cues is null))
+            object _lock = new();
+            Parallel.ForEach(acwbPaths, acwbPath =>
             {
-                Console.WriteLine(acwbPath.ACB);
-                string key = acwbPath.ACB.Substring((modPath.Length+1), acwbPath.ACB.Length-(modPath.Length+1));
-                lock (_lock)
+                ACB soundFile = new ACB(acwbPath.ACB, eventCues, acwbPath.AWB);
+                if (!(soundFile.Cues is null))
                 {
-                    if (key.EndsWith("BGM.ACB"))
-                        this.AcbByType["BGM"].Add(key);
-                    else if (key.EndsWith("SYSTEM.ACB"))
-                        this.AcbByType["System"].Add(key);
-                    else if (key.EndsWith("VOICE_SINGLEWORD.ACB"))
-                        this.AcbByType["Common"].Add(key);
-                    else if (Regex.IsMatch(key, "E[0-9][0-9][0-9]_[0-9][0-9][0-9]\\.ACB$"))
-                        this.AcbByType["Voice"].Add(key);
-                    else if (Regex.IsMatch(key, "E[0-9][0-9][0-9]_[0-9][0-9][0-9]_SE\\.ACB$"))
-                        this.AcbByType["SFX"].Add(key);
-                    else if (Regex.IsMatch(key, "F[0-9][0-9][0-9]_[0-9][0-9][0-9]\\.ACB$"))
-                        this.AcbByType["Field"].Add(key);
-                    this.AudioCueFiles[key] = soundFile;
-                    this.AcbList.Add(key);
+                    Console.WriteLine(acwbPath.ACB);
+                    string key = acwbPath.ACB.Substring((modPath.Length+1), acwbPath.ACB.Length-(modPath.Length+1));
+                    lock (_lock)
+                    {
+                        if (key.EndsWith("BGM.ACB"))
+                            this.AcbByType["BGM"].Add(key);
+                        else if (key.EndsWith("SYSTEM.ACB"))
+                            this.AcbByType["System"].Add(key);
+                        else if (key.EndsWith("VOICE_SINGLEWORD.ACB"))
+                            this.AcbByType["Common"].Add(key);
+                        else if (Regex.IsMatch(key, "E[0-9][0-9][0-9]_[0-9][0-9][0-9]\\.ACB$"))
+                            this.AcbByType["Voice"].Add(key);
+                        else if (Regex.IsMatch(key, "E[0-9][0-9][0-9]_[0-9][0-9][0-9]_SE\\.ACB$"))
+                            this.AcbByType["SFX"].Add(key);
+                        else if (Regex.IsMatch(key, "F[0-9][0-9][0-9]_[0-9][0-9][0-9]\\.ACB$"))
+                            this.AcbByType["Field"].Add(key);
+                        this.AudioCueFiles[key] = soundFile;
+                        this.AcbList.Add(key);
+                    }
                 }
-            }
-        });
+            });
+        }
         this.AcbList.Sort();
-        if (acwbPaths.Count > 0)
+        if (this.AcbList.Count > 0)
             this.ActiveACB = this.AcbList[0];
         else
             this.ActiveACB = null;

--- a/src/EVTUI/Core/DataManager.cs
+++ b/src/EVTUI/Core/DataManager.cs
@@ -86,18 +86,15 @@ public class DataManager
         if (!this.ReadOnly && !this.ProjectLoaded)
             return false;
 
-        //bool success = this.EventManager.Load(this.CpkList, $"E{majorId:000}_{minorId:000}", this.ModPath);
-        bool success = this.EventManager.Load(this.CpkList, $"E{majorId:000}_{minorId:000}", this.VanillaExtractionPath);
+        bool success = this.EventManager.Load(this.CpkList, $"E{majorId:000}_{minorId:000}", this.VanillaExtractionPath, this.ProjectManager.CpkDecryptionFunctionName);
         if (success)
             this.ProjectManager.LoadEvent(majorId, minorId);
         this.EventLoaded = success;
 
-        //this.ScriptManager.UpdateMessages(this.EventManager.BmdPaths, this.ModPath);
         this.ScriptManager.UpdateMessages(this.EventManager.BmdPaths, this.VanillaExtractionPath);
 
         // TODO: load common files! system sounds, common voice lines, models, bustups, cutins
         // so far, VOICE_SINGLEWORD gets loaded, but the rest will have to wait for full EVT/ECS parsing
-        //this.AudioManager.UpdateAudioCueFiles(this.EventManager.AcwbPaths, this.ModPath, this.ScriptManager.EventCues);
         this.AudioManager.UpdateAudioCueFiles(this.EventManager.AcwbPaths, this.VanillaExtractionPath, this.ScriptManager.EventCues);
 
         return true;
@@ -115,7 +112,7 @@ public class DataManager
 
     public List<(int MajorId, int MinorId)> ListAllEvents()
     {
-        return CPKExtract.ListAllEvents(this.CpkList);
+        return CPKExtract.ListAllEvents(this.CpkList, this.ProjectManager.CpkDecryptionFunctionName);
     }
 
     public void ClearCache()

--- a/src/EVTUI/Core/DataManager.cs
+++ b/src/EVTUI/Core/DataManager.cs
@@ -110,9 +110,17 @@ public class DataManager
         return cpks;
     }
 
-    public List<(int MajorId, int MinorId)> ListAllEvents()
+    public List<SimpleEvent> ListAllEvents()
     {
-        return CPKExtract.ListAllEvents(this.CpkList, this.ProjectManager.CpkDecryptionFunctionName);
+        List<SimpleEvent> ret = new List<SimpleEvent>();
+        foreach (var tuple in CPKExtract.ListAllEvents(this.CpkList, this.ProjectManager.CpkDecryptionFunctionName))
+        {
+            SimpleEvent evt = new SimpleEvent();
+            evt.MajorId = tuple.MajorId;
+            evt.MinorId = tuple.MinorId;
+            ret.Add(evt);
+        }
+        return ret;
     }
 
     public void ClearCache()

--- a/src/EVTUI/Core/EventManager.cs
+++ b/src/EVTUI/Core/EventManager.cs
@@ -65,9 +65,15 @@ public class EventManager
         this.AcwbPaths = new List<(string ACB, string? AWB)>();
         foreach (string acbPath in cpkEVTContents.Value.acbPaths)
         {
-            string awbPath = acbPath.Substring(0, acbPath.Length-4) + ".AWB";
-            if (cpkEVTContents.Value.awbPaths.Contains(awbPath))
-                this.AcwbPaths.Add((acbPath, awbPath));
+            //string awbPath = acbPath.Substring(0, acbPath.Length-4) + ".AWB";
+            //if (cpkEVTContents.Value.awbPaths.Contains(awbPath))
+            //    this.AcwbPaths.Add((acbPath, awbPath));
+            // TODO: smarter way to make this case-insensitive...
+            string basePath = acbPath.Substring(0, acbPath.Length-4);
+            if (cpkEVTContents.Value.awbPaths.Contains(basePath+".AWB"))
+                this.AcwbPaths.Add((acbPath, basePath+".AWB"));
+            else if (cpkEVTContents.Value.awbPaths.Contains(basePath+".awb"))
+                this.AcwbPaths.Add((acbPath, basePath+".awb"));
             else
                 this.AcwbPaths.Add((acbPath, null));
         }

--- a/src/EVTUI/Core/EventManager.cs
+++ b/src/EVTUI/Core/EventManager.cs
@@ -9,7 +9,6 @@ using System.Collections.Generic;
 
 namespace EVTUI;
 
-
 public struct CpkEVTContents
 {
     public string? evtPath;
@@ -22,15 +21,15 @@ public struct CpkEVTContents
     public CpkEVTContents() {}
 }
 
-
 public class EventManager
 {
 
     /////////////////////////////
     // *** PRIVATE MEMBERS *** //
     ///////////////./////////////
-    private EVT? SerialEvent       = null;
-    private ECS? SerialEventSounds = null;
+    private EVT?   SerialEvent               = null;
+    private ECS?   SerialEventSounds         = null;
+    private string CpkDecryptionFunctionName = null;
 
     ////////////////////////////
     // *** PUBLIC MEMBERS *** //
@@ -42,10 +41,12 @@ public class EventManager
     ////////////////////////////
     // *** PUBLIC METHODS *** //
     ////////////////////////////
-    public bool Load(List<string> cpkList, string evtid, string targetdir)
+    public bool Load(List<string> cpkList, string evtid, string targetdir, string cpkDecryptionFunctionName)
     {
         this.Clear();
-        CpkEVTContents? cpkEVTContents = CPKExtract.ExtractEVTFiles(cpkList, evtid, targetdir);
+        this.CpkDecryptionFunctionName = cpkDecryptionFunctionName;
+
+        CpkEVTContents? cpkEVTContents = CPKExtract.ExtractEVTFiles(cpkList, evtid, targetdir, this.CpkDecryptionFunctionName);
         if (cpkEVTContents is null)
             return false;
 
@@ -65,9 +66,6 @@ public class EventManager
         this.AcwbPaths = new List<(string ACB, string? AWB)>();
         foreach (string acbPath in cpkEVTContents.Value.acbPaths)
         {
-            //string awbPath = acbPath.Substring(0, acbPath.Length-4) + ".AWB";
-            //if (cpkEVTContents.Value.awbPaths.Contains(awbPath))
-            //    this.AcwbPaths.Add((acbPath, awbPath));
             // TODO: smarter way to make this case-insensitive...
             string basePath = acbPath.Substring(0, acbPath.Length-4);
             if (cpkEVTContents.Value.awbPaths.Contains(basePath+".AWB"))
@@ -108,8 +106,9 @@ public class EventManager
 
     public void Clear()
     {
-        this.SerialEvent       = null;
-        this.SerialEventSounds = null;
+        this.SerialEvent               = null;
+        this.SerialEventSounds         = null;
+        this.CpkDecryptionFunctionName = null;
     }
 
     public int EventDuration { get { return this.SerialEvent.TotalFrame; } }
@@ -175,7 +174,7 @@ public class EventManager
         if (pattern == "")
             return new List<string>();
         else
-            return CPKExtract.ExtractMatchingFiles(cpkList, pattern, targetdir);
+            return CPKExtract.ExtractMatchingFiles(cpkList, pattern, targetdir, this.CpkDecryptionFunctionName);
     }
 
     public List<string> GetAnimPaths(int assetId, bool fromBaseAnims, bool blendAnims, List<string> cpkList, string targetdir)
@@ -209,11 +208,11 @@ public class EventManager
             return new List<string>();
         else
         {
-            List<string> candidates = CPKExtract.ExtractMatchingFiles(cpkList, pattern, targetdir);
+            List<string> candidates = CPKExtract.ExtractMatchingFiles(cpkList, pattern, targetdir, this.CpkDecryptionFunctionName);
             if (candidates.Count == 0 && (ObjectTypes)obj.Type == ObjectTypes.Character)
             {
                 pattern = $"MODEL[\\\\/]CHARACTER[\\\\/]COMMON_ANIM[\\\\/]{animType}CMN{animId:0000}\\.GAP";
-                candidates = CPKExtract.ExtractMatchingFiles(cpkList, pattern, targetdir);
+                candidates = CPKExtract.ExtractMatchingFiles(cpkList, pattern, targetdir, this.CpkDecryptionFunctionName);
             }
             return candidates;
         }

--- a/src/EVTUI/Core/FileIO/CPKExtract.cs
+++ b/src/EVTUI/Core/FileIO/CPKExtract.cs
@@ -26,21 +26,33 @@ public static class CPKExtract
         }
     }
 
-    public static List<string> ExtractMatchingFiles(List<string> CpkList, string filePattern, string OutputFolder)
+    public static void ClearDirectory(string dirName)
     {
+        DirectoryInfo dirInfo = new DirectoryInfo(dirName);
+        foreach (FileInfo file in dirInfo.EnumerateFiles())
+            file.Delete(); 
+        foreach (DirectoryInfo dir in dirInfo.EnumerateDirectories())
+            dir.Delete(true); 
+    }
+
+    public static List<string> ExtractMatchingFiles(List<string> CpkList, string filePatternString, string OutputFolder)
+    {
+        Regex filePattern = new Regex(filePatternString, RegexOptions.IgnoreCase);
         List<string> matches = new List<string>();
         Parallel.ForEach(CpkList, CpkPath =>
         {
             CpkFile[] files;
             using (var fileStream = new FileStream(CpkPath, FileMode.Open))
             using (var reader = CriFsLib.Instance.CreateCpkReader(fileStream, true, CriFsLib.Instance.GetKnownDecryptionFunction(KnownDecryptionFunction.P5R)))
+            //using (var reader = CriFsLib.Instance.CreateCpkReader(fileStream, true))
                 { files = reader.GetFiles(); }
             using var extractor = CriFsLib.Instance.CreateBatchExtractor<ItemModel>(CpkPath, CriFsLib.Instance.GetKnownDecryptionFunction(KnownDecryptionFunction.P5R));
+            //using var extractor = CriFsLib.Instance.CreateBatchExtractor<ItemModel>(CpkPath);
             Parallel.For(0, files.Length, x =>
             {
                 var inCpkPath = Path.Combine(files[x].Directory ?? "", files[x].FileName);
                 var outputPath = Path.GetFullPath(Path.Combine(OutputFolder, Path.GetFileName(CpkPath), inCpkPath));
-                if (Regex.IsMatch(inCpkPath, filePattern))
+                if (filePattern.IsMatch(inCpkPath))
                 {
                     matches.Add(outputPath);
                     extractor.QueueItem(new ItemModel(outputPath, files[x]));
@@ -52,10 +64,66 @@ public static class CPKExtract
         return matches;
     }
 
+    private static Dictionary<string, Regex> Patterns = new Dictionary<string, Regex>()
+    {
+        ["EVT:EVT"] = new Regex("\\.EVT$",                 RegexOptions.IgnoreCase),
+        ["EVT:ECS"] = new Regex("\\.ECS$",                 RegexOptions.IgnoreCase),
+        ["EVT:ACB"] = new Regex("\\.ACB$",                 RegexOptions.IgnoreCase),
+        ["EVT:AWB"] = new Regex("\\.AWB$",                 RegexOptions.IgnoreCase),
+        ["EVT:BMD"] = new Regex("\\.BMD$",                 RegexOptions.IgnoreCase),
+        ["EVT:BF"]  = new Regex("\\.BF$",                  RegexOptions.IgnoreCase),
+        ["VSW:ACB"] = new Regex("VOICE_SINGLEWORD\\.ACB$", RegexOptions.IgnoreCase),
+        ["VSW:AWB"] = new Regex("VOICE_SINGLEWORD\\.AWB$", RegexOptions.IgnoreCase),
+        ["SYS:ACB"] = new Regex("SYSTEM\\.ACB$",           RegexOptions.IgnoreCase),
+        ["SYS:AWB"] = new Regex("SYSTEM\\.AWB$",           RegexOptions.IgnoreCase),
+        ["BGM:ACB"] = new Regex("BGM\\.ACB$",              RegexOptions.IgnoreCase),
+        ["BGM:AWB"] = new Regex("BGM\\.AWB$",              RegexOptions.IgnoreCase),
+    };
+
+    public static List<(int MajorId, int MinorId)> ListAllEvents(List<string> CpkList)
+    {
+        Regex pattern = new Regex("^EVENT[\\\\/]E\\d\\d\\d[\\\\/]E\\d\\d\\d[\\\\/]E\\d\\d\\d_\\d\\d\\d\\.EVT$", RegexOptions.IgnoreCase);
+        //List<(int MajorId, int MinorId)> events = new List<(int MajorId, int MinorId)>();
+        HashSet<(int MajorId, int MinorId)> events = new HashSet<(int MajorId, int MinorId)>();
+        object _lock = new();
+        Parallel.ForEach(CpkList, CpkPath =>
+        {
+            CpkFile[] files;
+            using (var fileStream = new FileStream(CpkPath, FileMode.Open))
+            using (var reader = CriFsLib.Instance.CreateCpkReader(fileStream, true, CriFsLib.Instance.GetKnownDecryptionFunction(KnownDecryptionFunction.P5R)))
+            //using (var reader = CriFsLib.Instance.CreateCpkReader(fileStream, true))
+            {
+                files = reader.GetFiles();
+            }
+
+            Parallel.For(0, files.Length, x =>
+            {
+                var inCpkPath = Path.Combine(files[x].Directory ?? "", files[x].FileName);
+                if (pattern.IsMatch(inCpkPath))
+                {
+                    //Console.WriteLine(files[x].FileName);
+                    //string basename = Path.GetFileNameWithoutExtension(inCpkPath);
+                    lock (_lock)
+                    {
+                        events.Add((int.Parse(files[x].FileName.Substring(1, 3)), int.Parse(files[x].FileName.Substring(5, 3))));
+                    }
+                }
+            });
+        });
+        //events.Sort();
+        //return events;
+        List<(int MajorId, int MinorId)> ret = new List<(int MajorId, int MinorId)>(events);
+        ret.Sort();
+        return ret;
+    }
+
     public static CpkEVTContents? ExtractEVTFiles(List<string> CpkList, string eventId, string OutputFolder)
     {
+        // clear it first!
+        CPKExtract.ClearDirectory(OutputFolder);
+
         var retval = new CpkEVTContents();
-        string eventPattern = $"[\\\\/]{eventId}([\\\\/\\.]|_SE)";
+        Regex eventPattern = new Regex($"[\\\\/]{eventId}([\\\\/\\.]|_SE)", RegexOptions.IgnoreCase);
         bool evtFound = false;
 
         Parallel.ForEach(CpkList, CpkPath =>
@@ -64,48 +132,50 @@ public static class CPKExtract
             CpkFile[] files;
             using (var fileStream = new FileStream(CpkPath, FileMode.Open))
             using (var reader = CriFsLib.Instance.CreateCpkReader(fileStream, true, CriFsLib.Instance.GetKnownDecryptionFunction(KnownDecryptionFunction.P5R)))
+            //using (var reader = CriFsLib.Instance.CreateCpkReader(fileStream, true))
             {
                 files = reader.GetFiles();
             }
 
             using var extractor = CriFsLib.Instance.CreateBatchExtractor<ItemModel>(CpkPath, CriFsLib.Instance.GetKnownDecryptionFunction(KnownDecryptionFunction.P5R));
+            //using var extractor = CriFsLib.Instance.CreateBatchExtractor<ItemModel>(CpkPath);
 
             Parallel.For(0, files.Length, x =>
             {
                 var inCpkPath = Path.Combine(files[x].Directory ?? "", files[x].FileName);
                 var outputPath = Path.GetFullPath(Path.Combine(OutputFolder, Path.GetFileName(CpkPath), inCpkPath));
-                if (Regex.IsMatch(inCpkPath, eventPattern))
+                if (eventPattern.IsMatch(inCpkPath))
                 {
                     Console.WriteLine(inCpkPath);
-                    if (Regex.IsMatch(inCpkPath, "\\.EVT$"))
+                    if (CPKExtract.Patterns["EVT:EVT"].IsMatch(inCpkPath))
                     {
                         evtFound = true;
                         retval.evtPath = outputPath;
                     }
-                    else if (Regex.IsMatch(inCpkPath, "\\.ECS$"))
+                    else if (CPKExtract.Patterns["EVT:ECS"].IsMatch(inCpkPath))
                         retval.ecsPath = outputPath;
-                    else if (Regex.IsMatch(inCpkPath, "\\.ACB$"))
+                    else if (CPKExtract.Patterns["EVT:ACB"].IsMatch(inCpkPath))
                         retval.acbPaths.Add(outputPath);
-                    else if (Regex.IsMatch(inCpkPath, "\\.AWB$"))
+                    else if (CPKExtract.Patterns["EVT:AWB"].IsMatch(inCpkPath))
                         retval.awbPaths.Add(outputPath);
-                    else if (Regex.IsMatch(inCpkPath, "\\.BMD$"))
+                    else if (CPKExtract.Patterns["EVT:BMD"].IsMatch(inCpkPath))
                         retval.bmdPaths.Add(outputPath);
-                    else if (Regex.IsMatch(inCpkPath, "\\.BF$"))
+                    else if (CPKExtract.Patterns["EVT:BF"].IsMatch(inCpkPath))
                         retval.bfPaths.Add(outputPath);
                     else
                         return;
                 }
-                else if (Regex.IsMatch(inCpkPath, "VOICE_SINGLEWORD\\.ACB$"))
+                else if (CPKExtract.Patterns["VSW:ACB"].IsMatch(inCpkPath))
                     retval.acbPaths.Add(outputPath);
-                else if (Regex.IsMatch(inCpkPath, "VOICE_SINGLEWORD\\.AWB$"))
+                else if (CPKExtract.Patterns["VSW:AWB"].IsMatch(inCpkPath))
                     retval.awbPaths.Add(outputPath);
-                else if (Regex.IsMatch(inCpkPath, "SYSTEM\\.ACB$"))
+                else if (CPKExtract.Patterns["SYS:ACB"].IsMatch(inCpkPath))
                     retval.acbPaths.Add(outputPath);
-                else if (Regex.IsMatch(inCpkPath, "SYSTEM\\.AWB$"))
+                else if (CPKExtract.Patterns["SYS:AWB"].IsMatch(inCpkPath))
                     retval.awbPaths.Add(outputPath);
-                else if (Regex.IsMatch(inCpkPath, "BGM\\.ACB$"))
+                else if (CPKExtract.Patterns["BGM:ACB"].IsMatch(inCpkPath))
                     retval.acbPaths.Add(outputPath);
-                else if (Regex.IsMatch(inCpkPath, "BGM\\.AWB$"))
+                else if (CPKExtract.Patterns["BGM:AWB"].IsMatch(inCpkPath))
                     retval.awbPaths.Add(outputPath);
                 else
                     return;

--- a/src/EVTUI/Core/FileIO/Formats/ACB/ADX.cs
+++ b/src/EVTUI/Core/FileIO/Formats/ACB/ADX.cs
@@ -145,6 +145,8 @@ public class Adx : ISerializable
 
     public void Crypt(ulong keyCode)
     {
+        if (keyCode == 0)
+            return;
         keyCode -= 1;
         int seed = (int)(keyCode >> 27)  & 0x7fff;
         int mult = (int)((keyCode >> 12) & 0x7ffc) | 1;

--- a/src/EVTUI/Core/FileIO/UserCache.cs
+++ b/src/EVTUI/Core/FileIO/UserCache.cs
@@ -37,9 +37,16 @@ Preferences: {}";
 
         TextReader yamlStream;
         if (File.Exists(UserCacheFile))
-            // TODO: put a try/except here to just open up a default yaml if load fails i.e. if the existing cache is deprecated/fucked
-            // or just return null and let App.axaml.cs handle it and show a popup....
-            yamlStream = new StreamReader(UserCacheFile);
+            // TODO: handle a failed read without just overwriting, as the below code inelegantly does
+            // e.g., just return null and let App.axaml.cs handle it and show a popup....
+            try
+            {
+                yamlStream = new StreamReader(UserCacheFile);
+            }
+            catch
+            {
+                yamlStream = new StringReader(DefaultYaml);
+            }
         else
             yamlStream = new StringReader(DefaultYaml);
         return Deserialize(yamlStream.ReadToEnd());

--- a/src/EVTUI/Core/FileIO/UserCache.cs
+++ b/src/EVTUI/Core/FileIO/UserCache.cs
@@ -13,10 +13,7 @@ public static class UserCache
     /////////////////////////////
     private static string DefaultYaml = @"
 Projects: []
-ReadOnly:
-  History:
-    CPKs: []
-    Events: []
+Games: []
 Preferences: {}";
     private static ISerializer Serializer = new SerializerBuilder()
                                .WithIndentedSequences()
@@ -40,6 +37,7 @@ Preferences: {}";
 
         TextReader yamlStream;
         if (File.Exists(UserCacheFile))
+            // TODO: put a try/except here to just open up a default yaml if load fails i.e. if the existing cache is deprecated/fucked
             yamlStream = new StreamReader(UserCacheFile);
         else
             yamlStream = new StringReader(DefaultYaml);
@@ -66,28 +64,28 @@ Preferences: {}";
 
 public class User
 {
-    public List<Project>    Projects              { get; set; }
-    public ReadOnlySettings ReadOnly              { get; set; }
+    public List<Project>              Projects    { get; set; }
+    public List<GameSettings>         Games       { get; set; }
     public Dictionary<string, object> Preferences { get; set; }
 }
 
 public class Project
 {
-    public ImmutableSettings Immutable { get; set; }
-    public MutableSettings   Mutable   { get; set; }
-    public ProjectHistory    History   { get; set; }
-}
-
-public class ImmutableSettings
-{
-    public GameSettings Game { get; set; }
-    public ModSettings Mod   { get; set; }
+    public string                   Name       { get; set; }
+    public string                   Notes      { get; set; }
+    public string                   Game       { get; set; }
+    public ModSettings              Mod        { get; set; }
+    public Dictionary<string, bool> Frameworks { get; set; }
+    public List<string>             LoadOrder  { get; set; }
+    public EventCollections         Events     { get; set; }
 }
 
 public class GameSettings
 {
-    public string Path { get; set; }
-    public string Type { get; set; }
+    public string           Path   { get; set; }
+    public string           Type   { get; set; }
+    public string           Notes  { get; set; }
+    public EventCollections Events { get; set; }
 }
 
 public class ModSettings
@@ -96,31 +94,22 @@ public class ModSettings
     public string Type { get; set; }
 }
 
-public class MutableSettings
+public class EventCollections
 {
-    public string                   Name       { get; set; }
-    public Dictionary<string, bool> Frameworks { get; set; }
-    public List<string>             LoadOrder  { get; set; }
+    public List<SimpleEvent>   Pinned { get; set; }
+    public List<SimpleEvent>   Recent { get; set; }
+    public List<ExpandedEvent> Notes  { get; set; }
 }
 
-public class ProjectHistory
+public class SimpleEvent
 {
-    public List<Event> Events { get; set; }
+    public int    MajorId { get; set; }
+    public int    MinorId { get; set; }
 }
 
-public class ReadOnlySettings
+public class ExpandedEvent
 {
-    public ReadOnlyHistory History { get; set; }
-}
-
-public class ReadOnlyHistory
-{
-    public List<string> CPKs   { get; set; }
-    public List<Event>  Events { get; set; }
-}
-
-public class Event
-{
-    public int MajorId { get; set; }
-    public int MinorId { get; set; }
+    public int    MajorId { get; set; }
+    public int    MinorId { get; set; }
+    public string Text    { get; set; }
 }

--- a/src/EVTUI/Core/FileIO/UserCache.cs
+++ b/src/EVTUI/Core/FileIO/UserCache.cs
@@ -38,6 +38,7 @@ Preferences: {}";
         TextReader yamlStream;
         if (File.Exists(UserCacheFile))
             // TODO: put a try/except here to just open up a default yaml if load fails i.e. if the existing cache is deprecated/fucked
+            // or just return null and let App.axaml.cs handle it and show a popup....
             yamlStream = new StreamReader(UserCacheFile);
         else
             yamlStream = new StringReader(DefaultYaml);

--- a/src/EVTUI/Core/ProjectManager.cs
+++ b/src/EVTUI/Core/ProjectManager.cs
@@ -215,6 +215,32 @@ public class ProjectManager
         this.SaveUserCache();
     }
 
+    public void SetProjectPin(Project project, int majorId, int minorId, bool hasPin)
+    {
+        (project.Events.Pinned).RemoveAll(evt => evt.MajorId == majorId && evt.MinorId == minorId);
+        if (hasPin)
+        {
+            SimpleEvent newEvent = new SimpleEvent();
+            newEvent.MajorId = majorId;
+            newEvent.MinorId = minorId;
+            project.Events.Pinned.Insert(0, newEvent);
+            this.SaveUserCache();
+        }
+    }
+
+    public void SetGamePin(GameSettings game, int majorId, int minorId, bool hasPin)
+    {
+        (game.Events.Pinned).RemoveAll(evt => evt.MajorId == majorId && evt.MinorId == minorId);
+        if (hasPin)
+        {
+            SimpleEvent newEvent = new SimpleEvent();
+            newEvent.MajorId = majorId;
+            newEvent.MinorId = minorId;
+            game.Events.Pinned.Insert(0, newEvent);
+            this.SaveUserCache();
+        }
+    }
+
     public void SetProjectEventNotes(int ind, int majorId, int minorId, string notes)
     {
         (this.UserData.Projects[ind].Events.Notes).RemoveAll(evt => evt.MajorId == majorId && evt.MinorId == minorId);

--- a/src/EVTUI/Core/ProjectManager.cs
+++ b/src/EVTUI/Core/ProjectManager.cs
@@ -1,8 +1,138 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 
 namespace EVTUI;
+
+/*public class User
+{
+    public User(SerialUser serialUser)
+    {
+        this.Games = new Dictionary<string, GameWrapper>();
+        foreach (ExpandedGameSettings game in serialUser.Games)
+            this.Games[game.Path] = new Game(game);
+
+        this.Projects = new Dictionary<string, ProjectWrapper>();
+        foreach (SerialProject project in serialUser.Projects)
+            this.Projects[project.Mod.Path] = new ProjectWrapper(project, this.Games[project.Game.Path]);
+
+        this.Preferences = serialUser.Preferences;
+    }
+
+    public Dictionary<string, ProjectWrapper> Projects    { get; set; }
+    public Dictionary<string, GameWrapper>    Games       { get; set; }
+    public Dictionary<string, object>         Preferences { get; set; }
+
+    public SerialUser Serialize()
+    {
+        SerialUser ret = new SerialUser();
+        return ret;
+    }
+}
+
+public class GameWrapper
+{
+    public GameWrapper(ExpandedGameSettings game)
+    {
+        this.GameSettings  = game;
+
+        this.EventNotes = new Dictionary<(int MajorId, int MinorId), string>();
+        foreach (ExpandedEvent evt in project.Events.Notes)
+            this.EventNotes[(evt.MajorId, evt.MinorId)] = evt.Text;
+    }
+
+    public ExpandedGameSettings                           GameSettings { get; set; }
+    public Dictionary<(int MajorId, int MinorId), string> EventNotes   { get; set; }
+
+    public ExpandedGameSettings Serialize()
+    {
+        ExpandedGameSettings ret = new ExpandedGameSettings();
+        return ret;
+    }
+}
+
+public class ProjectWrapper
+{
+    public ProjectWrapper(SerialProject project, ExpandedGameSettings game)
+    {
+        this.GameSettings  = game;
+        this.Project       = project;
+
+        this.EventNotes = new Dictionary<(int MajorId, int MinorId), string>();
+        foreach (ExpandedEvent evt in project.Events.Notes)
+            this.EventNotes[(evt.MajorId, evt.MinorId)] = evt.Text;
+    }
+
+    public ExpandedGameSettings                           GameSettings { get; set; }
+    public SerialProject                                  Project      { get; set; }
+    public Dictionary<(int MajorId, int MinorId), string> EventNotes   { get; set; }
+
+    public SerialProject Serialize()
+    {
+        SerialProject ret = new SerialProject();
+        return ret;
+    }
+}*/
+
+/*public class DisplayableEvent
+{
+    public Event(int majorId, int minorId, bool gamePin, bool projPin, string gameNotes, string projNotes)
+    {
+        this.MajorId   = majorId;
+        this.MinorId   = minorId;
+        this.GamePin   = gamePin;
+        this.ProjPin   = projPin;
+        this.GameNotes = gameNotes;
+        this.ProjNotes = projNotes;
+    }
+
+    public int    MajorId   { get; set; }
+    public int    MinorId   { get; set; }
+    public bool   GamePin   { get; set; }
+    public bool   ProjPin   { get; set; }
+    public string GameNotes { get; set; }
+    public string ProjNotes { get; set; }
+}*/
+
+public class NewProjectConfig
+{
+    public NewProjectConfig()
+    {
+        this.Name = "";
+        this.ModType = "Reloaded";
+        this.GameType = "P5R PC (Steam)";
+        this.Frameworks = new List<Framework>();
+        this.Frameworks.Add(new Framework("P5REssentials", true));
+        this.Frameworks.Add(new Framework("AWBEmulator", false));
+        this.Frameworks.Add(new Framework("BFEmulator", false));
+        this.Frameworks.Add(new Framework("BMDEmulator", false));
+        this.Frameworks.Add(new Framework("Ryo", false));
+        this.LoadOrder = new List<string>(["<PRIMARY_MOD_PLACEHOLDER>"]);
+    }
+
+    public string  GamePath { get; set; }
+    public string? ModPath  { get; set; }
+
+    public string Name      { get; set; }
+    public string ModType   { get; set; }
+    public string GameType  { get; set; }
+
+    public List<Framework> Frameworks { get; set; }
+    public List<string>    LoadOrder  { get; set; }
+}
+
+public class Framework
+{
+    public Framework(string name, bool used)
+    {
+        this.Name = name;
+        this.Used = used;
+    }
+
+    public string Name { get; set; }
+    public bool   Used { get; set; }
+}
 
 public class ProjectManager
 {
@@ -12,11 +142,23 @@ public class ProjectManager
     ////////////////////////////
     public User UserData;
 
+    private static Dictionary<string, ulong> KeyCodes = new Dictionary<string, ulong>()
+    {
+        ["P5R PC (Steam)"] = 9923540143823782,
+        ["P5 Dev Build"]   = 0,
+    };
+
     // the below wrappers keep the "latest project/cpk/event is always index zero"
     // thing contained to this class, so if that's confusing and/or changes in the future
     // it doesn't need to affect a bunch of other classes.
 
-    public Project? LatestProject
+    public GameSettings? ActiveGame;
+    public Project?      ActiveProject;
+    public SimpleEvent?  ActiveEvent;
+
+    public ulong AdxKey { get => (this.ActiveGame is null) ? 0 : ProjectManager.KeyCodes[this.ActiveGame.Type]; }
+
+    /*public Project? LatestProject
     {
         get
         {
@@ -32,7 +174,7 @@ public class ProjectManager
         get
         {
             if (this.UserData.Projects.Count > 0)
-                return this.UserData.Projects[0].Immutable.Game.Path;
+                return this.UserData.Projects[0].Game;
             else
                 return null;
         }
@@ -43,18 +185,18 @@ public class ProjectManager
         get
         {
             if (this.UserData.Projects.Count > 0)
-                return this.UserData.Projects[0].Immutable.Mod.Path;
+                return this.UserData.Projects[0].Mod.Path;
             else
                 return null;
         }
     }
 
-    public Event? LatestProjectEvent
+    public SimpleEvent? LatestProjectEvent
     {
         get
         {
-            if (this.UserData.Projects.Count > 0 && this.UserData.Projects[0].History.Events.Count > 0)
-                return this.UserData.Projects[0].History.Events[0];
+            if (this.UserData.Projects.Count > 0 && this.UserData.Projects[0].Events.Recent.Count > 0)
+                return this.UserData.Projects[0].Events.Recent[0];
             else
                 return null;
         }
@@ -64,23 +206,24 @@ public class ProjectManager
     {
         get
         {
-            if (this.UserData.ReadOnly.History.CPKs.Count > 0)
-                return this.UserData.ReadOnly.History.CPKs[0];
+            if (this.UserData.Games.Count > 0)
+                return this.UserData.Games[0].Path;
             else
                 return null;
         }
     }
 
-    public Event? LatestReadOnlyEvent
+    public SimpleEvent? LatestReadOnlyEvent
     {
         get
         {
-            if (this.UserData.ReadOnly.History.Events.Count > 0)
-                return this.UserData.ReadOnly.History.Events[0];
+            // TODO: this is not robust
+            if (this.UserData.Games[0].Events.Recent.Count > 0)
+                return this.UserData.Games[0].Events.Recent[0];
             else
                 return null;
         }
-    }
+    }*/
 
     ////////////////////////////
     // *** PUBLIC METHODS *** //
@@ -99,10 +242,10 @@ public class ProjectManager
         //this.SetProjectFramework(0, "BFEmulator", true);
         //this.SetProjectLoadOrder(0, new List<string>(["<PRIMARY_MOD_PLACEHOLDER>", "/path/to/YetAnotherMod"]));
         //if (!(this.ActiveProject is null))
-        //    Console.WriteLine(this.ActiveProject.Mutable.Name);
+        //    Console.WriteLine(this.ActiveProject.Name);
         //this.LoadProject(1);
         //if (!(this.ActiveProject is null))
-        //    Console.WriteLine(this.ActiveProject.Mutable.Name);
+        //    Console.WriteLine(this.ActiveProject.Name);
     }
 
     private void SaveUserCache()
@@ -113,41 +256,37 @@ public class ProjectManager
     public bool ModPathAlreadyUsed(string modPath)
     {
         foreach (Project oldProject in this.UserData.Projects)
-            if (oldProject.Immutable.Mod.Path == modPath)
+            if (oldProject.Mod.Path == modPath)
                 return true;
         return false;
     }
 
-    public bool TryUpdateProjects(string gamePath, string gameType, string modPath, string modType, string name, Dictionary<string, bool> frameworks, List<string> loadOrder)
+    //public bool TryUpdateProjects(string gamePath, string gameType, string modPath, string modType, string name, Dictionary<string, bool> frameworks, List<string> loadOrder)
+    public bool TryUpdateProjects(NewProjectConfig config)
     {
         // just gonna treat these as one for error catching purposes... sure hope i don't regret this later when debugging
-        if (this.ModPathAlreadyUsed(modPath) || !Directory.Exists(gamePath))
+        if (this.ModPathAlreadyUsed(config.ModPath) || !Directory.Exists(config.GamePath))
             return false;
 
-        GameSettings game = new GameSettings();
-        game.Path = gamePath;
-        game.Type = gameType;
+        //GameSettings game = new GameSettings();
+        //game.Path = gamePath;
+        //game.Type = gameType;
 
         ModSettings mod = new ModSettings();
-        mod.Path = modPath;
-        mod.Type = modType;
+        mod.Path = config.ModPath;
+        mod.Type = config.ModType;
 
-        ImmutableSettings immutable = new ImmutableSettings();
-        immutable.Game = game;
-        immutable.Mod = mod;
+        Dictionary<string, bool> frameworks = new Dictionary<string, bool>();
+        foreach (Framework framework in config.Frameworks)
+            frameworks[framework.Name] = framework.Used;
 
-        MutableSettings mutable = new MutableSettings();
-        mutable.Name = name;
-        mutable.Frameworks = frameworks;
-        mutable.LoadOrder = loadOrder;
-
-        ProjectHistory history = new ProjectHistory();
-        history.Events = new List<Event>();
-
-        Project project = new Project();
-        project.Immutable = immutable;
-        project.Mutable = mutable;
-        project.History = history;
+        Project project    = new Project();
+        project.Name       = config.Name;
+        project.Game       = config.GamePath;
+        project.Mod        = mod;
+        project.Frameworks = frameworks;
+        project.LoadOrder  = config.LoadOrder;
+        project.Events     = new EventCollections();
 
         this.UserData.Projects.Insert(0, project);
         this.SaveUserCache();
@@ -155,60 +294,196 @@ public class ProjectManager
         return true;
     }
 
-    public void UpdateProjectEvents(int ind, int majorId, int minorId)
+    /*public void UpdateProjectEvents(int ind, int majorId, int minorId)
     {
-        (this.UserData.Projects[ind].History.Events).RemoveAll(evt => evt.MajorId == majorId && evt.MinorId == minorId);
-        Event newEvent = new Event();
+        (this.UserData.Projects[ind].Events.Recent).RemoveAll(evt => evt.MajorId == majorId && evt.MinorId == minorId);
+        SimpleEvent newEvent = new SimpleEvent();
         newEvent.MajorId = majorId;
         newEvent.MinorId = minorId;
-        this.UserData.Projects[ind].History.Events.Insert(0, newEvent);
+        this.UserData.Projects[ind].Events.Recent.Insert(0, newEvent);
+        this.SaveUserCache();
+    }*/
+
+    // there's probably a better way to handle these errors...
+    public void LoadProject(int projInd)
+    {
+        Trace.Assert(projInd >= 0 && projInd < this.UserData.Projects.Count && this.UserData.Projects.Count > 0, "User project data is corrupted.");
+
+        if (projInd > 0)
+        {
+            Project project = this.UserData.Projects[projInd];
+            this.UserData.Projects.RemoveAt(projInd);
+            this.UserData.Projects.Insert(0, project);
+        }
+
+        this.ActiveGame = null;
+        for (int gameInd=0; gameInd<this.UserData.Games.Count; gameInd++)
+            if (this.UserData.Games[gameInd].Path == this.UserData.Projects[0].Game)
+            {
+                if (gameInd > 0)
+                {
+                    GameSettings game = this.UserData.Games[gameInd];
+                    this.UserData.Games.RemoveAt(gameInd);
+                    this.UserData.Games.Insert(0, game);
+                }
+                this.ActiveGame = this.UserData.Games[0];
+                this.ActiveProject = this.UserData.Projects[0];
+                break;
+            }
+
+        Trace.Assert(!(this.ActiveGame is null) && !(this.ActiveProject is null), "Game specified for project doesn't exist.");
+
         this.SaveUserCache();
     }
 
-    // ensure / break if ind is out of bounds / there are no projects...?
-    public void LoadProject(int ind)
+    public void LoadGameReadOnly(int gameInd)
     {
-        if (ind == 0)
-            return;
+        Trace.Assert(gameInd >= 0 && gameInd < this.UserData.Games.Count && this.UserData.Games.Count > 0, "User game path data is corrupted.");
 
-        Project project = this.UserData.Projects[ind];
-        this.UserData.Projects.RemoveAt(ind);
-        this.UserData.Projects.Insert(0, project);
-        this.SaveUserCache();
+        if (gameInd > 0)
+        {
+            GameSettings game = this.UserData.Games[gameInd];
+            this.UserData.Games.RemoveAt(gameInd);
+            this.UserData.Games.Insert(0, game);
+            this.SaveUserCache();
+        }
+
+        this.ActiveGame = this.UserData.Games[0];
+        this.ActiveProject = null;
+    }
+
+    public void LoadEvent(int majorId, int minorId)
+    {
+        if (!(this.ActiveProject is null))
+        {
+            (this.ActiveProject.Events.Recent).RemoveAll(evt => evt.MajorId == majorId && evt.MinorId == minorId);
+            SimpleEvent newEvent = new SimpleEvent();
+            newEvent.MajorId = majorId;
+            newEvent.MinorId = minorId;
+            this.ActiveProject.Events.Recent.Insert(0, newEvent);
+            this.ActiveEvent = newEvent;
+            this.SaveUserCache();
+        }
+
+        if (!(this.ActiveGame is null))
+        {
+            (this.ActiveGame.Events.Recent).RemoveAll(evt => evt.MajorId == majorId && evt.MinorId == minorId);
+            SimpleEvent newEvent = new SimpleEvent();
+            newEvent.MajorId = majorId;
+            newEvent.MinorId = minorId;
+            this.ActiveGame.Events.Recent.Insert(0, newEvent);
+            this.ActiveEvent = newEvent;
+            this.SaveUserCache();
+        }
     }
 
     public void SetProjectName(int ind, string name)
     {
-        this.UserData.Projects[ind].Mutable.Name = name;
+        this.UserData.Projects[ind].Name = name;
+        this.SaveUserCache();
+    }
+
+    public void SetProjectNotes(int ind, string notes)
+    {
+        this.UserData.Projects[ind].Notes = notes;
         this.SaveUserCache();
     }
 
     public void SetProjectFramework(int ind, string key, bool val)
     {
-        this.UserData.Projects[ind].Mutable.Frameworks[key] = val;
+        this.UserData.Projects[ind].Frameworks[key] = val;
         this.SaveUserCache();
     }
 
     public void SetProjectLoadOrder(int ind, List<string> loadOrder)
     {
-        this.UserData.Projects[ind].Mutable.LoadOrder = loadOrder;
+        this.UserData.Projects[ind].LoadOrder = loadOrder;
         this.SaveUserCache();
     }
 
-    public void UpdateReadOnlyCPKs(string path)
+    public void SetProjectEventNotes(int ind, int majorId, int minorId, string notes)
     {
-        (this.UserData.ReadOnly.History.CPKs).RemoveAll(cpk => cpk == path);
-        this.UserData.ReadOnly.History.CPKs.Insert(0, path);
+        (this.UserData.Projects[ind].Events.Notes).RemoveAll(evt => evt.MajorId == majorId && evt.MinorId == minorId);
+        if (notes != "")
+        {
+            ExpandedEvent updatedEvent = new ExpandedEvent();
+            updatedEvent.MajorId = majorId;
+            updatedEvent.MinorId = minorId;
+            updatedEvent.Text    = notes;
+            this.UserData.Projects[ind].Events.Notes.Insert(0, updatedEvent);
+        }
         this.SaveUserCache();
     }
 
-    public void UpdateReadOnlyEvents(int majorId, int minorId)
+    public void SetProjectEventNotes(Project project, int majorId, int minorId, string notes)
     {
-        (this.UserData.ReadOnly.History.Events).RemoveAll(evt => evt.MajorId == majorId && evt.MinorId == minorId);
-        Event newEvent = new Event();
+        (project.Events.Notes).RemoveAll(evt => evt.MajorId == majorId && evt.MinorId == minorId);
+        if (notes != "")
+        {
+            ExpandedEvent updatedEvent = new ExpandedEvent();
+            updatedEvent.MajorId = majorId;
+            updatedEvent.MinorId = minorId;
+            updatedEvent.Text    = notes;
+            project.Events.Notes.Insert(0, updatedEvent);
+        }
+        this.SaveUserCache();
+    }
+
+    public void SetGameNotes(int ind, string notes)
+    {
+        this.UserData.Games[ind].Notes = notes;
+        this.SaveUserCache();
+    }
+
+    public void SetGameEventNotes(int ind, int majorId, int minorId, string notes)
+    {
+        (this.UserData.Games[ind].Events.Notes).RemoveAll(evt => evt.MajorId == majorId && evt.MinorId == minorId);
+        if (notes != "")
+        {
+            ExpandedEvent updatedEvent = new ExpandedEvent();
+            updatedEvent.MajorId = majorId;
+            updatedEvent.MinorId = minorId;
+            updatedEvent.Text    = notes;
+            this.UserData.Games[ind].Events.Notes.Insert(0, updatedEvent);
+        }
+        this.SaveUserCache();
+    }
+
+    public void SetGameEventNotes(GameSettings game, int majorId, int minorId, string notes)
+    {
+        (game.Events.Notes).RemoveAll(evt => evt.MajorId == majorId && evt.MinorId == minorId);
+        if (notes != "")
+        {
+            ExpandedEvent updatedEvent = new ExpandedEvent();
+            updatedEvent.MajorId = majorId;
+            updatedEvent.MinorId = minorId;
+            updatedEvent.Text    = notes;
+            game.Events.Notes.Insert(0, updatedEvent);
+        }
+        this.SaveUserCache();
+    }
+
+    public void UpdateReadOnlyCPKs(string path, string type, string notes)
+    {
+        (this.UserData.Games).RemoveAll(game => game.Path == path && game.Type == type);
+        GameSettings newGame = new GameSettings();
+        newGame.Path = path;
+        newGame.Type = type;
+        newGame.Notes = notes;
+        newGame.Events = new EventCollections();
+        this.UserData.Games.Insert(0, newGame);
+        this.SaveUserCache();
+        this.ActiveGame = newGame;
+    }
+
+    /*public void UpdateReadOnlyEvents(int majorId, int minorId)
+    {
+        (this.UserData.Games[0].Events.Recent).RemoveAll(evt => evt.MajorId == majorId && evt.MinorId == minorId);
+        SimpleEvent newEvent = new SimpleEvent();
         newEvent.MajorId = majorId;
         newEvent.MinorId = minorId;
-        this.UserData.ReadOnly.History.Events.Insert(0, newEvent);
+        this.UserData.Games[0].Events.Recent.Insert(0, newEvent);
         this.SaveUserCache();
-    }
+    }*/
+
 }

--- a/src/EVTUI/Core/ProjectManager.cs
+++ b/src/EVTUI/Core/ProjectManager.cs
@@ -30,6 +30,8 @@ public class NewProjectConfig
 
     public List<Framework> Frameworks { get; set; }
     public List<string>    LoadOrder  { get; set; }
+
+    public static List<string> GameTypes { get; } = new List<string> {"P5R PC (Steam)", "P5 Dev Build"};
 }
 
 public class Framework

--- a/src/EVTUI/Core/ProjectManager.cs
+++ b/src/EVTUI/Core/ProjectManager.cs
@@ -5,96 +5,6 @@ using System.IO;
 
 namespace EVTUI;
 
-/*public class User
-{
-    public User(SerialUser serialUser)
-    {
-        this.Games = new Dictionary<string, GameWrapper>();
-        foreach (ExpandedGameSettings game in serialUser.Games)
-            this.Games[game.Path] = new Game(game);
-
-        this.Projects = new Dictionary<string, ProjectWrapper>();
-        foreach (SerialProject project in serialUser.Projects)
-            this.Projects[project.Mod.Path] = new ProjectWrapper(project, this.Games[project.Game.Path]);
-
-        this.Preferences = serialUser.Preferences;
-    }
-
-    public Dictionary<string, ProjectWrapper> Projects    { get; set; }
-    public Dictionary<string, GameWrapper>    Games       { get; set; }
-    public Dictionary<string, object>         Preferences { get; set; }
-
-    public SerialUser Serialize()
-    {
-        SerialUser ret = new SerialUser();
-        return ret;
-    }
-}
-
-public class GameWrapper
-{
-    public GameWrapper(ExpandedGameSettings game)
-    {
-        this.GameSettings  = game;
-
-        this.EventNotes = new Dictionary<(int MajorId, int MinorId), string>();
-        foreach (ExpandedEvent evt in project.Events.Notes)
-            this.EventNotes[(evt.MajorId, evt.MinorId)] = evt.Text;
-    }
-
-    public ExpandedGameSettings                           GameSettings { get; set; }
-    public Dictionary<(int MajorId, int MinorId), string> EventNotes   { get; set; }
-
-    public ExpandedGameSettings Serialize()
-    {
-        ExpandedGameSettings ret = new ExpandedGameSettings();
-        return ret;
-    }
-}
-
-public class ProjectWrapper
-{
-    public ProjectWrapper(SerialProject project, ExpandedGameSettings game)
-    {
-        this.GameSettings  = game;
-        this.Project       = project;
-
-        this.EventNotes = new Dictionary<(int MajorId, int MinorId), string>();
-        foreach (ExpandedEvent evt in project.Events.Notes)
-            this.EventNotes[(evt.MajorId, evt.MinorId)] = evt.Text;
-    }
-
-    public ExpandedGameSettings                           GameSettings { get; set; }
-    public SerialProject                                  Project      { get; set; }
-    public Dictionary<(int MajorId, int MinorId), string> EventNotes   { get; set; }
-
-    public SerialProject Serialize()
-    {
-        SerialProject ret = new SerialProject();
-        return ret;
-    }
-}*/
-
-/*public class DisplayableEvent
-{
-    public Event(int majorId, int minorId, bool gamePin, bool projPin, string gameNotes, string projNotes)
-    {
-        this.MajorId   = majorId;
-        this.MinorId   = minorId;
-        this.GamePin   = gamePin;
-        this.ProjPin   = projPin;
-        this.GameNotes = gameNotes;
-        this.ProjNotes = projNotes;
-    }
-
-    public int    MajorId   { get; set; }
-    public int    MinorId   { get; set; }
-    public bool   GamePin   { get; set; }
-    public bool   ProjPin   { get; set; }
-    public string GameNotes { get; set; }
-    public string ProjNotes { get; set; }
-}*/
-
 public class NewProjectConfig
 {
     public NewProjectConfig()
@@ -157,73 +67,7 @@ public class ProjectManager
     public SimpleEvent?  ActiveEvent;
 
     public ulong AdxKey { get => (this.ActiveGame is null) ? 0 : ProjectManager.KeyCodes[this.ActiveGame.Type]; }
-
-    /*public Project? LatestProject
-    {
-        get
-        {
-            if (this.UserData.Projects.Count > 0)
-                return this.UserData.Projects[0];
-            else
-                return null;
-        }
-    }
-
-    public string? LatestProjectGamePath
-    {
-        get
-        {
-            if (this.UserData.Projects.Count > 0)
-                return this.UserData.Projects[0].Game;
-            else
-                return null;
-        }
-    }
-
-    public string? LatestProjectModPath
-    {
-        get
-        {
-            if (this.UserData.Projects.Count > 0)
-                return this.UserData.Projects[0].Mod.Path;
-            else
-                return null;
-        }
-    }
-
-    public SimpleEvent? LatestProjectEvent
-    {
-        get
-        {
-            if (this.UserData.Projects.Count > 0 && this.UserData.Projects[0].Events.Recent.Count > 0)
-                return this.UserData.Projects[0].Events.Recent[0];
-            else
-                return null;
-        }
-    }
-
-    public string? LatestReadOnlyGamePath
-    {
-        get
-        {
-            if (this.UserData.Games.Count > 0)
-                return this.UserData.Games[0].Path;
-            else
-                return null;
-        }
-    }
-
-    public SimpleEvent? LatestReadOnlyEvent
-    {
-        get
-        {
-            // TODO: this is not robust
-            if (this.UserData.Games[0].Events.Recent.Count > 0)
-                return this.UserData.Games[0].Events.Recent[0];
-            else
-                return null;
-        }
-    }*/
+    public string CpkDecryptionFunctionName { get => (this.ActiveGame is null || !this.ActiveGame.Type.StartsWith("P5R")) ? null : "P5R"; }
 
     ////////////////////////////
     // *** PUBLIC METHODS *** //
@@ -231,21 +75,6 @@ public class ProjectManager
     public ProjectManager()
     {
         this.UserData = UserCache.InitializeOrLoadUser();
-
-        // TODO: make these into unit tests
-        //this.UpdateReadOnlyEvents(726, 84);
-        //this.UpdateReadOnlyCPKs("/path/to/CPKs");
-        //this.TryUpdateProjects("/path/to/CPKs", "P5R PC (Steam)", "/path/to/MyMod", "Reloaded", "My First Mod", new Dictionary<string, bool>{["AWBEmulator"]=false, ["BFEmulator"]=false, ["BGME"]=false}, new List<string>(["/path/to/OtherMod", "/path/to/AnotherMod", "<PRIMARY_MOD_PLACEHOLDER>"]));
-        //this.TryUpdateProjects("/path/to/CPKs", "P5R PC (Steam)", "/path/to/MyOtherMod", "Reloaded", "My Second Mod", new Dictionary<string, bool>(), new List<string>(["/path/to/OtherMod", "/path/to/AnotherMod", "<PRIMARY_MOD_PLACEHOLDER>"]));
-        //this.UpdateProjectEvents(0, 223, 1);
-        //this.SetProjectName(0, "My 1st Mod");
-        //this.SetProjectFramework(0, "BFEmulator", true);
-        //this.SetProjectLoadOrder(0, new List<string>(["<PRIMARY_MOD_PLACEHOLDER>", "/path/to/YetAnotherMod"]));
-        //if (!(this.ActiveProject is null))
-        //    Console.WriteLine(this.ActiveProject.Name);
-        //this.LoadProject(1);
-        //if (!(this.ActiveProject is null))
-        //    Console.WriteLine(this.ActiveProject.Name);
     }
 
     private void SaveUserCache()
@@ -261,16 +90,11 @@ public class ProjectManager
         return false;
     }
 
-    //public bool TryUpdateProjects(string gamePath, string gameType, string modPath, string modType, string name, Dictionary<string, bool> frameworks, List<string> loadOrder)
     public bool TryUpdateProjects(NewProjectConfig config)
     {
         // just gonna treat these as one for error catching purposes... sure hope i don't regret this later when debugging
         if (this.ModPathAlreadyUsed(config.ModPath) || !Directory.Exists(config.GamePath))
             return false;
-
-        //GameSettings game = new GameSettings();
-        //game.Path = gamePath;
-        //game.Type = gameType;
 
         ModSettings mod = new ModSettings();
         mod.Path = config.ModPath;
@@ -293,16 +117,6 @@ public class ProjectManager
 
         return true;
     }
-
-    /*public void UpdateProjectEvents(int ind, int majorId, int minorId)
-    {
-        (this.UserData.Projects[ind].Events.Recent).RemoveAll(evt => evt.MajorId == majorId && evt.MinorId == minorId);
-        SimpleEvent newEvent = new SimpleEvent();
-        newEvent.MajorId = majorId;
-        newEvent.MinorId = minorId;
-        this.UserData.Projects[ind].Events.Recent.Insert(0, newEvent);
-        this.SaveUserCache();
-    }*/
 
     // there's probably a better way to handle these errors...
     public void LoadProject(int projInd)
@@ -475,15 +289,5 @@ public class ProjectManager
         this.SaveUserCache();
         this.ActiveGame = newGame;
     }
-
-    /*public void UpdateReadOnlyEvents(int majorId, int minorId)
-    {
-        (this.UserData.Games[0].Events.Recent).RemoveAll(evt => evt.MajorId == majorId && evt.MinorId == minorId);
-        SimpleEvent newEvent = new SimpleEvent();
-        newEvent.MajorId = majorId;
-        newEvent.MinorId = minorId;
-        this.UserData.Games[0].Events.Recent.Insert(0, newEvent);
-        this.SaveUserCache();
-    }*/
 
 }

--- a/src/EVTUI/Core/ScriptManager.cs
+++ b/src/EVTUI/Core/ScriptManager.cs
@@ -288,15 +288,16 @@ public class ScriptManager
     {
         this.MessageFiles.Clear();
         this.BmdList.Clear();
-        foreach (var bmdPath in bmdPaths)
-        {
-            var messageFile = new BMD();
-            messageFile.Read(bmdPath);
-            string key = bmdPath.Substring((modPath.Length+1), bmdPath.Length-(modPath.Length+1));
-            this.MessageFiles[key] = messageFile;
-            this.BmdList.Add(key);
-        }
-        if (bmdPaths.Count > 0)
+        if (!(bmdPaths is null))
+            foreach (string bmdPath in bmdPaths)
+            {
+                var messageFile = new BMD();
+                messageFile.Read(bmdPath);
+                string key = bmdPath.Substring((modPath.Length+1), bmdPath.Length-(modPath.Length+1));
+                this.MessageFiles[key] = messageFile;
+                this.BmdList.Add(key);
+            }
+        if (this.BmdList.Count > 0)
             this.ActiveBMD = this.BmdList[0];
         else
             this.ActiveBMD = null;

--- a/src/EVTUI/Core/ScriptManager.cs
+++ b/src/EVTUI/Core/ScriptManager.cs
@@ -129,12 +129,13 @@ public class ScriptManager
         get
         {
             List<string> names = new List<string>();
-            foreach (Turn turn in this.MessageFiles[this.ActiveBMD].Turns)
-            {
-                string name = "";
-                foreach (Node node in this.Parse(turn.Name, this.ActiveBMD.Contains("BASE.CPK")))
-                    name += node.Text;
-            }
+            if (!(this.ActiveBMD is null))
+                foreach (Turn turn in this.MessageFiles[this.ActiveBMD].Turns)
+                {
+                    string name = "";
+                    foreach (Node node in this.Parse(turn.Name, this.ActiveBMD.Contains("BASE.CPK")))
+                        name += node.Text;
+                }
             return names;
         }
     }
@@ -144,14 +145,15 @@ public class ScriptManager
         get
         {
             List<string> names = new List<string>();
-            for (int i=0; i<this.MessageFiles[this.ActiveBMD].TurnCount; i++)
-            {
-                string name = "";
-                foreach (Node node in this.Parse(this.MessageFiles[this.ActiveBMD].Turns[i].Name, this.ActiveBMD.Contains("BASE.CPK")))
-                    name += node.Text;
-                if (this.MessageFiles[this.ActiveBMD].TurnKinds[i] == 0)
-                    names.Add(name);
-            }
+            if (!(this.ActiveBMD is null))
+                for (int i=0; i<this.MessageFiles[this.ActiveBMD].TurnCount; i++)
+                {
+                    string name = "";
+                    foreach (Node node in this.Parse(this.MessageFiles[this.ActiveBMD].Turns[i].Name, this.ActiveBMD.Contains("BASE.CPK")))
+                        name += node.Text;
+                    if (this.MessageFiles[this.ActiveBMD].TurnKinds[i] == 0)
+                        names.Add(name);
+                }
             return names;
         }
     }
@@ -161,14 +163,15 @@ public class ScriptManager
         get
         {
             List<string> names = new List<string>();
-            for (int i=0; i<this.MessageFiles[this.ActiveBMD].TurnCount; i++)
-            {
-                string name = "";
-                foreach (Node node in this.Parse(this.MessageFiles[this.ActiveBMD].Turns[i].Name, this.ActiveBMD.Contains("BASE.CPK")))
-                    name += node.Text;
-                if (this.MessageFiles[this.ActiveBMD].TurnKinds[i] != 0)
-                    names.Add(name);
-            }
+            if (!(this.ActiveBMD is null))
+                for (int i=0; i<this.MessageFiles[this.ActiveBMD].TurnCount; i++)
+                {
+                    string name = "";
+                    foreach (Node node in this.Parse(this.MessageFiles[this.ActiveBMD].Turns[i].Name, this.ActiveBMD.Contains("BASE.CPK")))
+                        name += node.Text;
+                    if (this.MessageFiles[this.ActiveBMD].TurnKinds[i] != 0)
+                        names.Add(name);
+                }
             return names;
         }
     }
@@ -178,100 +181,110 @@ public class ScriptManager
         get
         {
             List<string> names = new List<string>();
-            foreach (byte[] speaker in this.MessageFiles[this.ActiveBMD].Speakers)
+            if (!(this.ActiveBMD is null))
             {
-                string name = "";
-                foreach (Node node in this.Parse(speaker, this.ActiveBMD.Contains("BASE.CPK")))
-                    name += node.Text;
-                names.Add(name);
+                foreach (byte[] speaker in this.MessageFiles[this.ActiveBMD].Speakers)
+                {
+                    string name = "";
+                    foreach (Node node in this.Parse(speaker, this.ActiveBMD.Contains("BASE.CPK")))
+                        name += node.Text;
+                    names.Add(name);
+                }
+                names.Add("(UNNAMED)");
             }
-            names.Add("(UNNAMED)");
             return names;
         }
     }
 
     public int GetTurnIndex(Int16 majorId, byte minorId, byte _subId)
     {
-        // it works even without an exact subId match, so... fallback logic
-        foreach (byte subId in new[]{_subId, 0})
-        {
-            for (int i=0; i<this.MessageFiles[this.ActiveBMD].Turns.Length; i++)
+        if (!(this.ActiveBMD is null))
+            // it works even without an exact subId match, so... fallback logic
+            foreach (byte subId in new[]{_subId, 0})
             {
-                string name = "";
-                foreach (Node node in this.Parse(this.MessageFiles[this.ActiveBMD].Turns[i].Name, this.ActiveBMD.Contains("BASE.CPK")))
-                    name += node.Text;
-                if (Regex.IsMatch(name, $"^[A-Z][A-Z][A-Z]_{majorId:000}_{minorId}_{subId}$"))
-                    return i;
+                for (int i=0; i<this.MessageFiles[this.ActiveBMD].Turns.Length; i++)
+                {
+                    string name = "";
+                    foreach (Node node in this.Parse(this.MessageFiles[this.ActiveBMD].Turns[i].Name, this.ActiveBMD.Contains("BASE.CPK")))
+                        name += node.Text;
+                    if (Regex.IsMatch(name, $"^[A-Z][A-Z][A-Z]_{majorId:000}_{minorId}_{subId}$"))
+                        return i;
+                }
             }
-        }
         return -1;
     }
 
     public int GetTurnIndex(string targetName)
     {
-        for (int i=0; i<this.MessageFiles[this.ActiveBMD].Turns.Length; i++)
-        {
-            string name = "";
-            foreach (Node node in this.Parse(this.MessageFiles[this.ActiveBMD].Turns[i].Name, this.ActiveBMD.Contains("BASE.CPK")))
-                name += node.Text;
-            if (name == targetName)
-                return i;
-        }
+        if (!(this.ActiveBMD is null))
+            for (int i=0; i<this.MessageFiles[this.ActiveBMD].Turns.Length; i++)
+            {
+                string name = "";
+                foreach (Node node in this.Parse(this.MessageFiles[this.ActiveBMD].Turns[i].Name, this.ActiveBMD.Contains("BASE.CPK")))
+                    name += node.Text;
+                if (name == targetName)
+                    return i;
+            }
         return -1;
     }
 
     public string GetTurnName(int turnIndex)
     {
         string name = "";
-        if (turnIndex >= 0 && turnIndex < this.MessageFiles[this.ActiveBMD].Turns.Length)
-            foreach (Node node in this.Parse(this.MessageFiles[this.ActiveBMD].Turns[turnIndex].Name, this.ActiveBMD.Contains("BASE.CPK")))
-                name += node.Text;
+        if (!(this.ActiveBMD is null))
+            if (turnIndex >= 0 && turnIndex < this.MessageFiles[this.ActiveBMD].Turns.Length)
+                foreach (Node node in this.Parse(this.MessageFiles[this.ActiveBMD].Turns[turnIndex].Name, this.ActiveBMD.Contains("BASE.CPK")))
+                    name += node.Text;
         return name;
     }
 
     public string GetTurnSpeakerName(int turnIndex)
     {
         string name = "";
-        if (turnIndex >= 0 && turnIndex < this.MessageFiles[this.ActiveBMD].Turns.Length && this.MessageFiles[this.ActiveBMD].Turns[turnIndex].SpeakerId != 0xFFFF)
-            foreach (Node node in this.Parse(this.MessageFiles[this.ActiveBMD].Speakers[this.MessageFiles[this.ActiveBMD].Turns[turnIndex].SpeakerId], this.ActiveBMD.Contains("BASE.CPK")))
-                name += node.Text;
+        if (!(this.ActiveBMD is null))
+            if (turnIndex >= 0 && turnIndex < this.MessageFiles[this.ActiveBMD].Turns.Length && this.MessageFiles[this.ActiveBMD].Turns[turnIndex].SpeakerId != 0xFFFF)
+                foreach (Node node in this.Parse(this.MessageFiles[this.ActiveBMD].Speakers[this.MessageFiles[this.ActiveBMD].Turns[turnIndex].SpeakerId], this.ActiveBMD.Contains("BASE.CPK")))
+                    name += node.Text;
         return name;
     }
 
     public int GetTurnElemCount(int turnIndex)
     {
-        if (turnIndex >= 0 && turnIndex < this.MessageFiles[this.ActiveBMD].Turns.Length)
-            return this.MessageFiles[this.ActiveBMD].Turns[turnIndex].ElemCount;
+        if (!(this.ActiveBMD is null))
+            if (turnIndex >= 0 && turnIndex < this.MessageFiles[this.ActiveBMD].Turns.Length)
+                return this.MessageFiles[this.ActiveBMD].Turns[turnIndex].ElemCount;
         return 0;
     }
 
     public string GetTurnText(int turnIndex, int elemIndex)
     {
         string text = "";
-        if (turnIndex >= 0 && turnIndex < this.MessageFiles[this.ActiveBMD].Turns.Length)
-            foreach (Node node in this.Parse(this.MessageFiles[this.ActiveBMD].Turns[turnIndex].Elems[elemIndex], this.ActiveBMD.Contains("BASE.CPK")))
-                text += node.Text;
+        if (!(this.ActiveBMD is null))
+            if (turnIndex >= 0 && turnIndex < this.MessageFiles[this.ActiveBMD].Turns.Length)
+                foreach (Node node in this.Parse(this.MessageFiles[this.ActiveBMD].Turns[turnIndex].Elems[elemIndex], this.ActiveBMD.Contains("BASE.CPK")))
+                    text += node.Text;
         return text;
     }
 
     public (string Source, uint CueId)? GetTurnVoice(int turnIndex, int elemIndex)
     {
-        foreach (Node node in this.Parse(this.MessageFiles[this.ActiveBMD].Turns[turnIndex].Elems[elemIndex], this.ActiveBMD.Contains("BASE.CPK")))
-            if (node.FunctionTableIndex == 3 && node.FunctionIndex == 1 && node.FunctionArguments[3] != 0)
-                switch (node.FunctionArguments[1])
-                {
-                    case 0:
-                        if (this.GetTurnSpeakerName(turnIndex).StartsWith("(SE)"))
-                            return ("SFX", node.FunctionArguments[3]);
-                        else
-                            return ("Voice", node.FunctionArguments[3]);
-                    case 1:
-                        return ("Field", node.FunctionArguments[3]);
-                    case 2:
-                        return ("Common", node.FunctionArguments[3]);
-                    default:
-                        break;
-                }
+        if (!(this.ActiveBMD is null))
+            foreach (Node node in this.Parse(this.MessageFiles[this.ActiveBMD].Turns[turnIndex].Elems[elemIndex], this.ActiveBMD.Contains("BASE.CPK")))
+                if (node.FunctionTableIndex == 3 && node.FunctionIndex == 1 && node.FunctionArguments[3] != 0)
+                    switch (node.FunctionArguments[1])
+                    {
+                        case 0:
+                            if (this.GetTurnSpeakerName(turnIndex).StartsWith("(SE)"))
+                                return ("SFX", node.FunctionArguments[3]);
+                            else
+                                return ("Voice", node.FunctionArguments[3]);
+                        case 1:
+                            return ("Field", node.FunctionArguments[3]);
+                        case 2:
+                            return ("Common", node.FunctionArguments[3]);
+                        default:
+                            break;
+                    }
         return null;
     }
 

--- a/src/EVTUI/Program.cs
+++ b/src/EVTUI/Program.cs
@@ -2,17 +2,26 @@
 using Avalonia.ReactiveUI;
 using System;
 using System.Collections.ObjectModel;
+using System.Threading;
 
 namespace EVTUI;
 
 sealed class Program
 {
+    private static string AppName = "Global\\EVTUI";
+    private static Mutex AppMutex = new Mutex(initiallyOwned: true, AppName);
+
     // Initialization code. Don't use any Avalonia, third-party APIs or any
     // SynchronizationContext-reliant code before AppMain is called: things aren't initialized
     // yet and stuff might break.
     [STAThread]
-    public static void Main(string[] args) => BuildAvaloniaApp()
-        .StartWithClassicDesktopLifetime(args);
+    public static void Main(string[] args)
+    {
+        if (AppMutex.WaitOne(TimeSpan.Zero, true))
+            BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
+        else
+            Console.WriteLine("EVTUI instance already open.");
+    }
 
     // Avalonia configuration, don't remove; also used by visual designer.
     public static AppBuilder BuildAvaloniaApp()

--- a/src/EVTUI/UI/ConfigWindow/ConfigurationPanel/ConfigurationPanel.axaml
+++ b/src/EVTUI/UI/ConfigWindow/ConfigurationPanel/ConfigurationPanel.axaml
@@ -141,7 +141,7 @@
 
           <!-- MOD DIR CONFIG -->
           <TabItem Header="Select Mod Folder"><StackPanel>
-            <Button Command="{Binding SetModDir}"><StackPanel>
+            <Button Click="GetModDirPathFromDialog"><StackPanel>
               <PathIcon Data="{StaticResource folder_add_regular}"/>
               <TextBlock Text="Pick New Folder"/>
             </StackPanel></Button>
@@ -156,13 +156,13 @@
                   <DataGridTextColumn Header="Game (CPK) Folder" Binding="{Binding Directory}"/>
                 </DataGrid.Columns>
               </DataGrid>
-              <Button Command="{Binding UseSelectedCpkDir}"><StackPanel>
+              <Button Click="GetSelectedCpkDir"><StackPanel>
                 <PathIcon Data="{StaticResource folder_open_regular}"/>
                 <TextBlock Text="Use Selected Folder"/>
               </StackPanel></Button>
             </StackPanel>
             <TextBlock Classes="tableplaceholder" Text="No recent folders." IsVisible="{Binding NoRecentCpkDirs}"/>
-            <Button Command="{Binding SetCPKs}"><StackPanel>
+            <Button Click="GetCpkDirPathFromDialog"><StackPanel>
               <PathIcon Data="{StaticResource folder_add_regular}"/>
               <TextBlock Text="Pick New Folder"/>
             </StackPanel></Button>
@@ -179,7 +179,7 @@
           <TextBlock Text="Path to CPK directory:"/>
           <TextBox Classes="readonly" Text="{Binding DisplayCPKPath}"/>
         </StackPanel>
-        <Button Command="{Binding CreateProject}" HorizontalAlignment="Right"><StackPanel>
+        <Button Click="CreateProject" HorizontalAlignment="Right"><StackPanel>
           <PathIcon Data="{StaticResource arrow_next_regular}"/>
           <TextBlock Text="Create &amp; Continue"/>
         </StackPanel></Button>
@@ -202,8 +202,7 @@
               <DataGridTextColumn Header="Game (CPK) Folder" Binding="{Binding GamePath}" />
             </DataGrid.Columns>
           </DataGrid>
-          <!--Button Command="{Binding SetProject}"><StackPanel-->
-          <Button Click="SetProject"><StackPanel>
+          <Button Click="UseProject"><StackPanel>
               <PathIcon Data="{StaticResource arrow_next_regular}"/>
               <TextBlock Text="Load Selected Project &amp; Continue"/>
           </StackPanel></Button>
@@ -229,28 +228,17 @@
                 <DataGridTextColumn Header="Game (CPK) Folder" Binding="{Binding Directory}"/>
               </DataGrid.Columns>
             </DataGrid>
-            <Button Command="{Binding UseSelectedCpkDir}"><StackPanel>
+            <Button Click="GetSelectedCpkDir"><StackPanel>
               <PathIcon Data="{StaticResource folder_open_regular}"/>
               <TextBlock Text="Use Selected Folder"/>
             </StackPanel></Button>
           </StackPanel>
           <TextBlock Classes="tableplaceholder" Text="No recent folders." IsVisible="{Binding NoRecentCpkDirs}"/>
-          <Button Command="{Binding SetCPKs}"><StackPanel>
+          <Button Click="GetCpkDirPathFromDialog"><StackPanel>
             <PathIcon Data="{StaticResource folder_add_regular}"/>
             <TextBlock Text="Pick New Folder"/>
           </StackPanel></Button>
         </StackPanel>
-
-        <Separator/>
-        <StackPanel Classes="formentry" HorizontalAlignment="Right">
-          <TextBlock Text="Path to CPK directory:"/>
-          <TextBox Classes="readonly" Text="{Binding DisplayCPKPath}"/>
-        </StackPanel>
-        <Button Command="{Binding InitReadOnly}" HorizontalAlignment="Right"><StackPanel>
-          <PathIcon Data="{StaticResource arrow_next_regular}"/>
-          <TextBlock Text="Open &amp; Continue"/>
-        </StackPanel></Button>
-        <Separator/>
 
       </StackPanel>
 
@@ -260,15 +248,14 @@
         <TextBlock Classes="paneltitle" Text="Select Event"/>
         <Separator/>
 
-        <StackPanel IsVisible="{Binding AnyRecentEvents}">
+        <StackPanel IsVisible="{Binding AnyRecentEvents, Mode=TwoWay}">
           <TextBlock Classes="tabletitle" Text="Recent Events"/>
-          <DataGrid ItemsSource="{Binding EventList}" SelectedItem="{Binding EventSelection}">
+          <DataGrid ItemsSource="{Binding EventList, Mode=TwoWay}" SelectedItem="{Binding EventSelection, Mode=TwoWay}">
             <DataGrid.Columns>
               <DataGridTextColumn Header="Major ID" Binding="{Binding MajorId}"/>
               <DataGridTextColumn Header="Minor ID" Binding="{Binding MinorId}" />
             </DataGrid.Columns>
           </DataGrid>
-          <!--Button Command="{Binding UseSelectedEvent}"><StackPanel-->
           <Button Click="UseSelectedEvent"><StackPanel>
             <PathIcon Data="{StaticResource document_regular}"/>
             <TextBlock Text="Load Selected Event"/>
@@ -286,8 +273,7 @@
             <NumericUpDown Value="{Binding EventMinorId}" Increment="1" FormatString="000" Minimum="0" Maximum="999"/>
           </StackPanel>
         </WrapPanel>
-        <Button Command="{Binding SetEVT}">
-        <!--Button Click="SetEVT"-->
+        <Button Click="UseEnteredEvent">
           <!-- I want this to happen eventually re: new events, but it's not ready for the big time yet. -->
           <!--SplitButton.Flyout>
             <MenuFlyout Placement="RightEdgeAlignedTop">
@@ -304,17 +290,6 @@
             <TextBlock Text="Pick Entered Event"/>
           </StackPanel>
         </Button>
-
-        <!--Separator/>
-        <StackPanel Classes="formentry" HorizontalAlignment="Right">
-          <TextBlock Text="Loaded event:"/>
-          <TextBox Classes="readonly" Text="{Binding DisplayLoadedEvent}"/>
-        </StackPanel>
-        <Button Command="{Binding FinishConfigStartEdit}" HorizontalAlignment="Right"><StackPanel>
-          <PathIcon Data="{StaticResource arrow_next_regular}"/>
-          <TextBlock Text="Finish Config &amp; View Event"/>
-        </StackPanel></Button>
-        <Separator/-->
 
       </StackPanel>
 

--- a/src/EVTUI/UI/ConfigWindow/ConfigurationPanel/ConfigurationPanel.axaml
+++ b/src/EVTUI/UI/ConfigWindow/ConfigurationPanel/ConfigurationPanel.axaml
@@ -267,6 +267,8 @@
               <DataGrid.Columns>
                 <DataGridTextColumn Header="Major ID" Binding="{Binding MajorId}" IsReadOnly="True" />
                 <DataGridTextColumn Header="Minor ID" Binding="{Binding MinorId}" IsReadOnly="True" />
+                <DataGridCheckBoxColumn Header="Pin for Project" Binding="{Binding HasProjPin}" IsVisible="{Binding ProjectLoaded}" IsReadOnly="False" />
+                <DataGridCheckBoxColumn Header="Pin for Game" Binding="{Binding HasGamePin}" IsReadOnly="False" />
                 <DataGridTextColumn Header="Project Notes" Binding="{Binding ProjNotes}" IsVisible="{Binding ProjectLoaded}" IsReadOnly="False" />
                 <DataGridTextColumn Header="Game Notes" Binding="{Binding GameNotes}" IsReadOnly="False" />
               </DataGrid.Columns>

--- a/src/EVTUI/UI/ConfigWindow/ConfigurationPanel/ConfigurationPanel.axaml
+++ b/src/EVTUI/UI/ConfigWindow/ConfigurationPanel/ConfigurationPanel.axaml
@@ -255,10 +255,19 @@
             </StackPanel></Button>
           </StackPanel>
           <TextBlock Classes="tableplaceholder" Text="No recent folders." IsVisible="{Binding NoRecentGames}"/>
-          <Button Click="GetGamePathFromDialog"><StackPanel>
-            <PathIcon Data="{StaticResource folder_add_regular}"/>
-            <TextBlock Text="Pick New Folder"/>
-          </StackPanel></Button>
+          <Separator/>
+          <StackPanel HorizontalAlignment="Center" Orientation="Horizontal">
+            <Button Click="GetGamePathFromDialog"><StackPanel>
+              <PathIcon Data="{StaticResource folder_add_regular}"/>
+              <TextBlock Text="Pick New Folder"/>
+            </StackPanel></Button>
+            <TextBlock Text="for game type" VerticalAlignment="Center" Margin="5" />
+            <ComboBox
+              ItemsSource="{Binding newProjectConfig.GameTypes}"
+              SelectedItem="{Binding newProjectConfig.GameType}"
+              MaxDropDownHeight="300"
+              VerticalAlignment="Center" />
+          </StackPanel>
         </StackPanel>
 
       </StackPanel>

--- a/src/EVTUI/UI/ConfigWindow/ConfigurationPanel/ConfigurationPanel.axaml
+++ b/src/EVTUI/UI/ConfigWindow/ConfigurationPanel/ConfigurationPanel.axaml
@@ -171,10 +171,19 @@
               </StackPanel></Button>
             </StackPanel>
             <TextBlock Classes="tableplaceholder" Text="No recent folders." IsVisible="{Binding NoRecentGames}"/>
-            <Button Click="GetGamePathFromDialog"><StackPanel>
-              <PathIcon Data="{StaticResource folder_add_regular}"/>
-              <TextBlock Text="Pick New Folder"/>
-            </StackPanel></Button>
+            <Separator/>
+            <StackPanel HorizontalAlignment="Center" Orientation="Horizontal">
+              <Button Click="GetGamePathFromDialog"><StackPanel>
+                <PathIcon Data="{StaticResource folder_add_regular}"/>
+                <TextBlock Text="Pick New Folder"/>
+              </StackPanel></Button>
+              <TextBlock Text="for game type" VerticalAlignment="Center" Margin="5" />
+              <ComboBox
+                ItemsSource="{Binding newProjectConfig.GameTypes}"
+                SelectedItem="{Binding newProjectConfig.GameType}"
+                MaxDropDownHeight="300"
+                VerticalAlignment="Center" />
+            </StackPanel>
           </StackPanel></TabItem>
 
         </TabControl>

--- a/src/EVTUI/UI/ConfigWindow/ConfigurationPanel/ConfigurationPanel.axaml
+++ b/src/EVTUI/UI/ConfigWindow/ConfigurationPanel/ConfigurationPanel.axaml
@@ -4,6 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:rxui="http://reactiveui.net"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             xmlns:m="using:EVTUI"
              xmlns:vm="using:EVTUI.ViewModels"
              xmlns:views="using:EVTUI.Views"
              x:DataType="vm:ConfigurationPanelViewModel"
@@ -47,6 +48,11 @@
       <Setter Property="FontWeight" Value="Light"/>
       <Setter Property="HorizontalAlignment" Value="Center"/>
     </Style>
+    <Style Selector="ComboBox.tabletitle">
+      <Setter Property="FontSize" Value="16"/>
+      <Setter Property="FontWeight" Value="Light"/>
+      <Setter Property="HorizontalAlignment" Value="Center"/>
+    </Style>
     <Style Selector="TextBlock.tableplaceholder">
       <Setter Property="FontSize" Value="16"/>
       <Setter Property="FontStyle" Value="Italic"/>
@@ -74,9 +80,9 @@
       <Setter Property="CanUserReorderColumns" Value="True"/>
       <Setter Property="CanUserResizeColumns" Value="True"/>
       <Setter Property="GridLinesVisibility" Value="All"/>
-      <Setter Property="Height" Value="NaN"/>
+      <!--Setter Property="Height" Value="NaN"/-->
+      <Setter Property="Height" Value="300"/>
       <Setter Property="HorizontalAlignment" Value="Center"/>
-      <Setter Property="IsReadOnly" Value="True"/>
       <Setter Property="Margin" Value="20"/>
       <Setter Property="VerticalAlignment" Value="Top"/>
       <Setter Property="Width" Value="NaN"/>
@@ -99,11 +105,20 @@
       <Setter Property="Margin" Value="5"/>
       <Setter Property="Width" Value="300"/>
     </Style>
-    <Style Selector="StackPanel.formentry > StackPanel.checkboxes">
+    <!--Style Selector="StackPanel.formentry > StackPanel.checkboxes"-->
+    <Style Selector="StackPanel.formentry > ItemsControl.checkboxes">
       <Setter Property="Margin" Value="5"/>
-      <Setter Property="Orientation" Value="Vertical"/>
+      <!--Setter Property="Orientation" Value="Vertical"/-->
     </Style>
   </UserControl.Styles>
+
+  <UserControl.DataTemplates>
+    <DataTemplate DataType="{x:Type m:Framework}">
+      <CheckBox IsChecked="{Binding Used}">
+        <TextBlock Text="{Binding Name}"/>
+      </CheckBox>
+    </DataTemplate>
+  </UserControl.DataTemplates>
 
   <ScrollViewer><StackPanel Orientation="Vertical" VerticalAlignment="Top" HorizontalAlignment="Center">
 
@@ -126,17 +141,18 @@
           <TabItem Header="Set Project Info"><StackPanel>
             <StackPanel Classes="formentry" HorizontalAlignment="Left">
               <TextBlock Text="Project/Mod Name:"/>
-              <TextBox Classes="editable" Text="{Binding ModName}"/>
+              <TextBox Classes="editable" Text="{Binding newProjectConfig.Name}"/>
             </StackPanel>
             <!-- (commented out because the booleans are unused for now, but it works fine) -->
-            <!--StackPanel Classes="formentry" HorizontalAlignment="Left">
+            <StackPanel Classes="formentry" HorizontalAlignment="Left">
               <TextBlock Text="Frameworks:"/>
-              <StackPanel Classes="checkboxes">
+              <!--StackPanel Classes="checkboxes">
                 <CheckBox IsChecked="{Binding UseAwbEmu}">AWBEmulator</CheckBox>
                 <CheckBox IsChecked="{Binding UseBfEmu}">BFEmulator</CheckBox>
-                <CheckBox IsChecked="{Binding UseBgmEmu}">BGME</CheckBox>
-              </StackPanel>
-            </StackPanel-->
+                <CheckBox IsChecked="{Binding UseRyo}">Ryo</CheckBox>
+              </StackPanel-->
+              <ItemsControl Classes="checkboxes" ItemsSource="{Binding newProjectConfig.Frameworks}" />
+            </StackPanel>
           </StackPanel></TabItem>
 
           <!-- MOD DIR CONFIG -->
@@ -149,20 +165,22 @@
 
           <!-- CPK DIR CONFIG -->
           <TabItem Header="Select Game (CPK) Folder"><StackPanel>
-            <StackPanel IsVisible="{Binding AnyRecentCpkDirs}">
+            <StackPanel IsVisible="{Binding AnyRecentGames}">
               <TextBlock Classes="tabletitle" Text="Recent Folders"/>
-              <DataGrid ItemsSource="{Binding CpkDirList}" SelectedItem="{Binding CpkDirSelection}">
+              <DataGrid ItemsSource="{Binding GameList}" SelectedItem="{Binding GameSelection}">
                 <DataGrid.Columns>
-                  <DataGridTextColumn Header="Game (CPK) Folder" Binding="{Binding Directory}"/>
+                  <DataGridTextColumn Header="Game Type" Binding="{Binding Type}" IsReadOnly="True"/>
+                  <DataGridTextColumn Header="Notes" Binding="{Binding Notes}" IsReadOnly="False"/>
+                  <DataGridTextColumn Header="Game (CPK) Folder" Binding="{Binding Path}" IsReadOnly="True"/>
                 </DataGrid.Columns>
               </DataGrid>
-              <Button Click="GetSelectedCpkDir"><StackPanel>
+              <Button Click="GetSelectedGame"><StackPanel>
                 <PathIcon Data="{StaticResource folder_open_regular}"/>
                 <TextBlock Text="Use Selected Folder"/>
               </StackPanel></Button>
             </StackPanel>
-            <TextBlock Classes="tableplaceholder" Text="No recent folders." IsVisible="{Binding NoRecentCpkDirs}"/>
-            <Button Click="GetCpkDirPathFromDialog"><StackPanel>
+            <TextBlock Classes="tableplaceholder" Text="No recent folders." IsVisible="{Binding NoRecentGames}"/>
+            <Button Click="GetGamePathFromDialog"><StackPanel>
               <PathIcon Data="{StaticResource folder_add_regular}"/>
               <TextBlock Text="Pick New Folder"/>
             </StackPanel></Button>
@@ -197,9 +215,10 @@
           <TextBlock Classes="tabletitle" Text="Recent Projects"/>
           <DataGrid ItemsSource="{Binding ProjectList}" SelectedItem="{Binding ProjectSelection}">
             <DataGrid.Columns>
-              <DataGridTextColumn Header="Project Name" Binding="{Binding Name}"/>
-              <DataGridTextColumn Header="Mod Folder" Binding="{Binding ModPath}" />
-              <DataGridTextColumn Header="Game (CPK) Folder" Binding="{Binding GamePath}" />
+              <DataGridTextColumn Header="Project Name" Binding="{Binding Name}" IsReadOnly="False"/>
+              <DataGridTextColumn Header="Notes" Binding="{Binding Notes}" IsReadOnly="False"/>
+              <DataGridTextColumn Header="Mod Folder" Binding="{Binding ModPath}" IsReadOnly="True"/>
+              <DataGridTextColumn Header="Game (CPK) Folder" Binding="{Binding GamePath}" IsReadOnly="True"/>
             </DataGrid.Columns>
           </DataGrid>
           <Button Click="UseProject"><StackPanel>
@@ -221,20 +240,22 @@
         <!-- CPK DIR CONFIG -->
         <StackPanel>
           <TextBlock Classes="sectiontitle" Text="Select Game (CPK) Folder"/>
-          <StackPanel IsVisible="{Binding AnyRecentCpkDirs}">
+          <StackPanel IsVisible="{Binding AnyRecentGames}">
             <TextBlock Classes="tabletitle" Text="Recent Folders"/>
-            <DataGrid ItemsSource="{Binding CpkDirList}" SelectedItem="{Binding CpkDirSelection}">
+            <DataGrid ItemsSource="{Binding GameList}" SelectedItem="{Binding GameSelection}">
               <DataGrid.Columns>
-                <DataGridTextColumn Header="Game (CPK) Folder" Binding="{Binding Directory}"/>
+                <DataGridTextColumn Header="Game Type" Binding="{Binding Type}" IsReadOnly="True"/>
+                <DataGridTextColumn Header="Notes" Binding="{Binding Notes}" IsReadOnly="False"/>
+                <DataGridTextColumn Header="Game (CPK) Folder" Binding="{Binding Path}" IsReadOnly="True"/>
               </DataGrid.Columns>
             </DataGrid>
-            <Button Click="GetSelectedCpkDir"><StackPanel>
+            <Button Click="GetSelectedGame"><StackPanel>
               <PathIcon Data="{StaticResource folder_open_regular}"/>
               <TextBlock Text="Use Selected Folder"/>
             </StackPanel></Button>
           </StackPanel>
-          <TextBlock Classes="tableplaceholder" Text="No recent folders." IsVisible="{Binding NoRecentCpkDirs}"/>
-          <Button Click="GetCpkDirPathFromDialog"><StackPanel>
+          <TextBlock Classes="tableplaceholder" Text="No recent folders." IsVisible="{Binding NoRecentGames}"/>
+          <Button Click="GetGamePathFromDialog"><StackPanel>
             <PathIcon Data="{StaticResource folder_add_regular}"/>
             <TextBlock Text="Pick New Folder"/>
           </StackPanel></Button>
@@ -248,18 +269,23 @@
         <TextBlock Classes="paneltitle" Text="Select Event"/>
         <Separator/>
 
-        <StackPanel IsVisible="{Binding AnyRecentEvents, Mode=TwoWay}">
-          <TextBlock Classes="tabletitle" Text="Recent Events"/>
-          <DataGrid ItemsSource="{Binding EventList, Mode=TwoWay}" SelectedItem="{Binding EventSelection, Mode=TwoWay}">
-            <DataGrid.Columns>
-              <DataGridTextColumn Header="Major ID" Binding="{Binding MajorId}"/>
-              <DataGridTextColumn Header="Minor ID" Binding="{Binding MinorId}" />
-            </DataGrid.Columns>
-          </DataGrid>
-          <Button Click="UseSelectedEvent"><StackPanel>
-            <PathIcon Data="{StaticResource document_regular}"/>
-            <TextBlock Text="Load Selected Event"/>
-          </StackPanel></Button>
+        <StackPanel>
+          <!--TextBlock Classes="tabletitle" Text="Recent Events"/-->
+          <ComboBox Classes="tabletitle" ItemsSource="{Binding EventCollections}" SelectedItem="{Binding SelectedCollection}" />
+          <StackPanel IsVisible="{Binding AnyRecentEvents, Mode=TwoWay}">
+            <DataGrid ItemsSource="{Binding EventList, Mode=TwoWay}" SelectedItem="{Binding EventSelection, Mode=TwoWay}" IsVisible="{Binding AnyRecentEvents, Mode=TwoWay}">
+              <DataGrid.Columns>
+                <DataGridTextColumn Header="Major ID" Binding="{Binding MajorId}" />
+                <DataGridTextColumn Header="Minor ID" Binding="{Binding MinorId}" />
+                <DataGridTextColumn Header="Project Notes" Binding="{Binding ProjNotes}" IsVisible="{Binding ProjectLoaded}" />
+                <DataGridTextColumn Header="Game Notes" Binding="{Binding GameNotes}" />
+              </DataGrid.Columns>
+            </DataGrid>
+            <Button Click="UseSelectedEvent"><StackPanel>
+              <PathIcon Data="{StaticResource document_regular}"/>
+              <TextBlock Text="Load Selected Event"/>
+            </StackPanel></Button>
+          </StackPanel>
         </StackPanel>
         <TextBlock Classes="tableplaceholder" Text="No recent events." IsVisible="{Binding NoRecentEvents}"/>
         <Separator/>

--- a/src/EVTUI/UI/ConfigWindow/ConfigurationPanel/ConfigurationPanel.axaml
+++ b/src/EVTUI/UI/ConfigWindow/ConfigurationPanel/ConfigurationPanel.axaml
@@ -202,7 +202,8 @@
               <DataGridTextColumn Header="Game (CPK) Folder" Binding="{Binding GamePath}" />
             </DataGrid.Columns>
           </DataGrid>
-          <Button Command="{Binding SetProject}"><StackPanel>
+          <!--Button Command="{Binding SetProject}"><StackPanel-->
+          <Button Click="SetProject"><StackPanel>
               <PathIcon Data="{StaticResource arrow_next_regular}"/>
               <TextBlock Text="Load Selected Project &amp; Continue"/>
           </StackPanel></Button>
@@ -267,7 +268,8 @@
               <DataGridTextColumn Header="Minor ID" Binding="{Binding MinorId}" />
             </DataGrid.Columns>
           </DataGrid>
-          <Button Command="{Binding UseSelectedEvent}"><StackPanel>
+          <!--Button Command="{Binding UseSelectedEvent}"><StackPanel-->
+          <Button Click="UseSelectedEvent"><StackPanel>
             <PathIcon Data="{StaticResource document_regular}"/>
             <TextBlock Text="Load Selected Event"/>
           </StackPanel></Button>
@@ -285,6 +287,7 @@
           </StackPanel>
         </WrapPanel>
         <Button Command="{Binding SetEVT}">
+        <!--Button Click="SetEVT"-->
           <!-- I want this to happen eventually re: new events, but it's not ready for the big time yet. -->
           <!--SplitButton.Flyout>
             <MenuFlyout Placement="RightEdgeAlignedTop">
@@ -302,7 +305,7 @@
           </StackPanel>
         </Button>
 
-        <Separator/>
+        <!--Separator/>
         <StackPanel Classes="formentry" HorizontalAlignment="Right">
           <TextBlock Text="Loaded event:"/>
           <TextBox Classes="readonly" Text="{Binding DisplayLoadedEvent}"/>
@@ -311,7 +314,7 @@
           <PathIcon Data="{StaticResource arrow_next_regular}"/>
           <TextBlock Text="Finish Config &amp; View Event"/>
         </StackPanel></Button>
-        <Separator/>
+        <Separator/-->
 
       </StackPanel>
 

--- a/src/EVTUI/UI/ConfigWindow/ConfigurationPanel/ConfigurationPanel.axaml
+++ b/src/EVTUI/UI/ConfigWindow/ConfigurationPanel/ConfigurationPanel.axaml
@@ -80,7 +80,6 @@
       <Setter Property="CanUserReorderColumns" Value="True"/>
       <Setter Property="CanUserResizeColumns" Value="True"/>
       <Setter Property="GridLinesVisibility" Value="All"/>
-      <!--Setter Property="Height" Value="NaN"/-->
       <Setter Property="Height" Value="300"/>
       <Setter Property="HorizontalAlignment" Value="Center"/>
       <Setter Property="Margin" Value="20"/>
@@ -105,10 +104,8 @@
       <Setter Property="Margin" Value="5"/>
       <Setter Property="Width" Value="300"/>
     </Style>
-    <!--Style Selector="StackPanel.formentry > StackPanel.checkboxes"-->
     <Style Selector="StackPanel.formentry > ItemsControl.checkboxes">
       <Setter Property="Margin" Value="5"/>
-      <!--Setter Property="Orientation" Value="Vertical"/-->
     </Style>
   </UserControl.Styles>
 
@@ -143,14 +140,8 @@
               <TextBlock Text="Project/Mod Name:"/>
               <TextBox Classes="editable" Text="{Binding newProjectConfig.Name}"/>
             </StackPanel>
-            <!-- (commented out because the booleans are unused for now, but it works fine) -->
             <StackPanel Classes="formentry" HorizontalAlignment="Left">
               <TextBlock Text="Frameworks:"/>
-              <!--StackPanel Classes="checkboxes">
-                <CheckBox IsChecked="{Binding UseAwbEmu}">AWBEmulator</CheckBox>
-                <CheckBox IsChecked="{Binding UseBfEmu}">BFEmulator</CheckBox>
-                <CheckBox IsChecked="{Binding UseRyo}">Ryo</CheckBox>
-              </StackPanel-->
               <ItemsControl Classes="checkboxes" ItemsSource="{Binding newProjectConfig.Frameworks}" />
             </StackPanel>
           </StackPanel></TabItem>
@@ -270,7 +261,6 @@
         <Separator/>
 
         <StackPanel>
-          <!--TextBlock Classes="tabletitle" Text="Recent Events"/-->
           <ComboBox Classes="tabletitle" ItemsSource="{Binding EventCollections}" SelectedItem="{Binding SelectedCollection}" />
           <StackPanel IsVisible="{Binding AnyRecentEvents, Mode=TwoWay}">
             <DataGrid ItemsSource="{Binding EventList, Mode=TwoWay}" SelectedItem="{Binding EventSelection, Mode=TwoWay}" IsVisible="{Binding AnyRecentEvents, Mode=TwoWay}">

--- a/src/EVTUI/UI/ConfigWindow/ConfigurationPanel/ConfigurationPanel.axaml
+++ b/src/EVTUI/UI/ConfigWindow/ConfigurationPanel/ConfigurationPanel.axaml
@@ -275,10 +275,10 @@
           <StackPanel IsVisible="{Binding AnyRecentEvents, Mode=TwoWay}">
             <DataGrid ItemsSource="{Binding EventList, Mode=TwoWay}" SelectedItem="{Binding EventSelection, Mode=TwoWay}" IsVisible="{Binding AnyRecentEvents, Mode=TwoWay}">
               <DataGrid.Columns>
-                <DataGridTextColumn Header="Major ID" Binding="{Binding MajorId}" />
-                <DataGridTextColumn Header="Minor ID" Binding="{Binding MinorId}" />
-                <DataGridTextColumn Header="Project Notes" Binding="{Binding ProjNotes}" IsVisible="{Binding ProjectLoaded}" />
-                <DataGridTextColumn Header="Game Notes" Binding="{Binding GameNotes}" />
+                <DataGridTextColumn Header="Major ID" Binding="{Binding MajorId}" IsReadOnly="True" />
+                <DataGridTextColumn Header="Minor ID" Binding="{Binding MinorId}" IsReadOnly="True" />
+                <DataGridTextColumn Header="Project Notes" Binding="{Binding ProjNotes}" IsVisible="{Binding ProjectLoaded}" IsReadOnly="False" />
+                <DataGridTextColumn Header="Game Notes" Binding="{Binding GameNotes}" IsReadOnly="False" />
               </DataGrid.Columns>
             </DataGrid>
             <Button Click="UseSelectedEvent"><StackPanel>

--- a/src/EVTUI/UI/ConfigWindow/ConfigurationPanel/ConfigurationPanel.axaml.cs
+++ b/src/EVTUI/UI/ConfigWindow/ConfigurationPanel/ConfigurationPanel.axaml.cs
@@ -1,26 +1,17 @@
+using System;
+using System.Threading.Tasks;
+
+using ReactiveUI;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
 using Avalonia.ReactiveUI;
+
 using EVTUI.ViewModels;
-using ReactiveUI;
-using System;
-using System.IO;
-using System.Reactive;
-using System.Threading.Tasks;
-using System.Windows.Input;
 
 namespace EVTUI.Views;
 
 public partial class ConfigurationPanel : ReactiveUserControl<ConfigurationPanelViewModel>
 {
-
-    private string ConfigType
-    {
-        get
-        {
-            return ((ConfigurationPanelViewModel)DataContext).ConfigType;
-        }
-    }
 
     private Window topLevel;
 
@@ -34,85 +25,28 @@ public partial class ConfigurationPanel : ReactiveUserControl<ConfigurationPanel
             if (tl is null) throw new NullReferenceException();
             this.topLevel = (Window)tl;
 
-            if (this.ConfigType == "new-proj")
-                pages.SelectedIndex = 1;
-            else if (this.ConfigType == "open-proj")
-                pages.SelectedIndex = 2;
-            else if (this.ConfigType == "read-only")
-                pages.SelectedIndex = 3;
-            else
-                pages.SelectedIndex = 0;
-            d(ViewModel!.GetCPKDirectoryFromView.RegisterHandler(GetCpkDirPathFromDialog));
-            d(ViewModel!.GetModDirectoryFromView.RegisterHandler(GetModDirPathFromDialog));
-            d(ViewModel!.DisplayMessage.RegisterHandler(DisplayMessageBox));
-            d(ViewModel!.OpenEventConfig.RegisterHandler(GoToEventPage));
-            d(ViewModel!.FinishConfig.RegisterHandler(CloseModal));
+            switch (ViewModel!.ConfigType)
+            {
+                case "new-proj":
+                    pages.SelectedIndex = 1;
+                    break;
+                case "open-proj":
+                    pages.SelectedIndex = 2;
+                    break;
+                case "read-only":
+                    pages.SelectedIndex = 3;
+                    break;
+                default:
+                    pages.SelectedIndex = 0;
+                    break;
+            }
         });
-    }
-
-    private async Task GoToEventPage(InteractionContext<Unit, bool> interaction)
-    {
-        pages.SelectedIndex = 4;
-        interaction.SetOutput(true);
-    }
-
-    private async Task GetCpkDirPathFromDialog(InteractionContext<Unit, string?> interaction)
-    {
-        var tl = TopLevel.GetTopLevel(this);
-        if (tl is null) throw new NullReferenceException();
-        var topLevel = (Window)tl;
-
-        // Start async operation to open the dialog.
-        var dirs = await topLevel.StorageProvider.OpenFolderPickerAsync(new Avalonia.Platform.Storage.FolderPickerOpenOptions
-        {
-            Title = "Open CPK Directory",
-            AllowMultiple = false
-        });
-
-        if (dirs.Count > 0)
-            interaction.SetOutput(dirs[0].Path.AbsolutePath);
-        else
-            interaction.SetOutput(null);
-    }
-
-    private async Task GetModDirPathFromDialog(InteractionContext<Unit, string?> interaction)
-    {
-        var tl = TopLevel.GetTopLevel(this);
-        if (tl is null) throw new NullReferenceException();
-        var topLevel = (Window)tl;
-
-        // Start async operation to open the dialog.
-        var dirs = await topLevel.StorageProvider.OpenFolderPickerAsync(new Avalonia.Platform.Storage.FolderPickerOpenOptions
-        {
-            Title = "Open Mod Directory",
-            AllowMultiple = false
-        });
-
-        if (dirs.Count > 0)
-            interaction.SetOutput(dirs[0].Path.AbsolutePath);
-        else
-            interaction.SetOutput(null);
-    }
-
-    public async Task DisplayMessageBox(InteractionContext<string, bool> interaction)
-    {
-        // Hiding RaiseModal inside this function suppresses a
-        // "[IME] Error while destroying the context:
-        // Tmds.DBus.Protocol.DBusException: org.freedesktop.DBus.Error.UnknownMethod: 
-        // Method Destroy is not implemented on interface org.freedesktop.IBus.Service"
-        // exception apparently caused by a bug in the Avalonia 11.0 release.
-        int closecode = await RaiseModal(interaction.Input);
-        interaction.SetOutput(closecode == 0);
-        return;
     }
 
     // If we need to pop boxes like this from multiple places, we should add this to
     // a View base class or something.
     public async Task<int> RaiseModal(string text)
     {
-        var tl = TopLevel.GetTopLevel(this);
-        if (tl is null) throw new NullReferenceException();
-        var topLevel = (Window)tl;
         Window sampleWindow =
             new Window 
             { 
@@ -123,36 +57,113 @@ public partial class ConfigurationPanel : ReactiveUserControl<ConfigurationPanel
 
         // Launch window and get a return code to distinguish how the window
         // was closed.
-        int? res = await sampleWindow.ShowDialog<int?>(topLevel);
+        int? res = await sampleWindow.ShowDialog<int?>(this.topLevel);
         if (res is null)
             return 1;
         else
             return (int)res;
     }
 
-    public async Task CloseModal(InteractionContext<int?,bool> interaction)
+    private void GoToEventPage()
     {
-        var tl = TopLevel.GetTopLevel(this);
-        if (tl is null) throw new NullReferenceException();
-        var topLevel = (Window)tl;
-        interaction.SetOutput(true);
-        topLevel.Close(interaction.Input);
+        pages.SelectedIndex = 4;
     }
 
-    public async void SetProject(object sender, RoutedEventArgs e)
+    ///////////////////////////////////
+    // *** PROJECT CREATION FORM *** //
+    ///////////////////////////////////
+
+    public async void GetModDirPathFromDialog(object sender, RoutedEventArgs e)
     {
-        var retTuple = ViewModel!.TrySetProject();
-        await RaiseModal(retTuple.Message);
-        if (retTuple.Status == 0)
-            pages.SelectedIndex = 4;
+        // Start async operation to open the dialog.
+        var dirs = await this.topLevel.StorageProvider.OpenFolderPickerAsync(new Avalonia.Platform.Storage.FolderPickerOpenOptions
+        {
+            Title = "Open Mod Directory",
+            AllowMultiple = false
+        });
+
+        if (dirs.Count > 0)
+        {
+            var retTuple = ViewModel!.TrySetModDir(dirs[0].Path.AbsolutePath);
+            if (retTuple.Status != 0)
+                await RaiseModal(retTuple.Message);
+        }
     }
+
+    public async void CreateProject(object sender, RoutedEventArgs e)
+    {
+        var retTuple = ViewModel!.TryCreateProject();
+        if (retTuple.Status == 0)
+            this.GoToEventPage();
+        else
+            await RaiseModal(retTuple.Message);
+    }
+
+    ////////////////////////////
+    // *** CPK SETUP FORM *** //
+    ////////////////////////////
+
+    public async void GetSelectedCpkDir(object sender, RoutedEventArgs e)
+    {
+        var retTuple = ViewModel!.TryUseCPKDir(null);
+        if (retTuple.Status != 0)
+            await RaiseModal(retTuple.Message);
+        else if (ViewModel!.ConfigType == "read-only")
+            this.GoToEventPage();
+    }
+
+    public async void GetCpkDirPathFromDialog(object sender, RoutedEventArgs e)
+    {
+        // Start async operation to open the dialog.
+        var dirs = await this.topLevel.StorageProvider.OpenFolderPickerAsync(new Avalonia.Platform.Storage.FolderPickerOpenOptions
+        {
+            Title = "Open CPK Directory",
+            AllowMultiple = false
+        });
+
+        if (dirs.Count > 0)
+        {
+            var retTuple = ViewModel!.TryUseCPKDir(dirs[0].Path.AbsolutePath);
+            if (retTuple.Status != 0)
+                await RaiseModal(retTuple.Message);
+            else if (ViewModel!.ConfigType == "read-only")
+                this.GoToEventPage();
+        }
+    }
+
+    ////////////////////////////////////
+    // *** PROJECT SELECTION FORM *** //
+    ////////////////////////////////////
+
+    public async void UseProject(object sender, RoutedEventArgs e)
+    {
+        var retTuple = ViewModel!.TryLoadProject();
+        if (retTuple.Status == 0)
+            this.GoToEventPage();
+        else
+            await RaiseModal(retTuple.Message);
+    }
+
+    //////////////////////////////////
+    // *** EVENT SELECTION FORM *** //
+    //////////////////////////////////
 
     public async void UseSelectedEvent(object sender, RoutedEventArgs e)
     {
-        var retTuple = ViewModel!.TryLoadEvent();
-        await RaiseModal(retTuple.Message);
+        var retTuple = ViewModel!.TryLoadEvent(true);
         if (retTuple.Status == 0)
             this.topLevel.Close(0);
+        else
+            await RaiseModal(retTuple.Message);
+    }
+
+    public async void UseEnteredEvent(object sender, RoutedEventArgs e)
+    {
+        var retTuple = ViewModel!.TryLoadEvent(false);
+        if (retTuple.Status == 0)
+            this.topLevel.Close(0);
+        else
+            await RaiseModal(retTuple.Message);
     }
 
 }

--- a/src/EVTUI/UI/ConfigWindow/ConfigurationPanel/ConfigurationPanel.axaml.cs
+++ b/src/EVTUI/UI/ConfigWindow/ConfigurationPanel/ConfigurationPanel.axaml.cs
@@ -66,6 +66,7 @@ public partial class ConfigurationPanel : ReactiveUserControl<ConfigurationPanel
 
     private void GoToEventPage()
     {
+        ViewModel!.DisplayEvents();
         pages.SelectedIndex = 4;
     }
 
@@ -103,16 +104,16 @@ public partial class ConfigurationPanel : ReactiveUserControl<ConfigurationPanel
     // *** CPK SETUP FORM *** //
     ////////////////////////////
 
-    public async void GetSelectedCpkDir(object sender, RoutedEventArgs e)
+    public async void GetSelectedGame(object sender, RoutedEventArgs e)
     {
-        var retTuple = ViewModel!.TryUseCPKDir(null);
+        var retTuple = ViewModel!.TryUseCPKDir(null, null);
         if (retTuple.Status != 0)
             await RaiseModal(retTuple.Message);
         else if (ViewModel!.ConfigType == "read-only")
             this.GoToEventPage();
     }
 
-    public async void GetCpkDirPathFromDialog(object sender, RoutedEventArgs e)
+    public async void GetGamePathFromDialog(object sender, RoutedEventArgs e)
     {
         // Start async operation to open the dialog.
         var dirs = await this.topLevel.StorageProvider.OpenFolderPickerAsync(new Avalonia.Platform.Storage.FolderPickerOpenOptions
@@ -123,7 +124,7 @@ public partial class ConfigurationPanel : ReactiveUserControl<ConfigurationPanel
 
         if (dirs.Count > 0)
         {
-            var retTuple = ViewModel!.TryUseCPKDir(dirs[0].Path.AbsolutePath);
+            var retTuple = ViewModel!.TryUseCPKDir(dirs[0].Path.AbsolutePath, ViewModel!.newProjectConfig.GameType);
             if (retTuple.Status != 0)
                 await RaiseModal(retTuple.Message);
             else if (ViewModel!.ConfigType == "read-only")
@@ -139,7 +140,10 @@ public partial class ConfigurationPanel : ReactiveUserControl<ConfigurationPanel
     {
         var retTuple = ViewModel!.TryLoadProject();
         if (retTuple.Status == 0)
+        {
+            this.topLevel.Title = $"EVTUI ({ViewModel!.Config.ProjectManager.ActiveProject.Name})";
             this.GoToEventPage();
+        }
         else
             await RaiseModal(retTuple.Message);
     }

--- a/src/EVTUI/UI/ConfigWindow/ConfigurationPanel/ConfigurationPanel.axaml.cs
+++ b/src/EVTUI/UI/ConfigWindow/ConfigurationPanel/ConfigurationPanel.axaml.cs
@@ -22,12 +22,18 @@ public partial class ConfigurationPanel : ReactiveUserControl<ConfigurationPanel
         }
     }
 
+    private Window topLevel;
+
     public ConfigurationPanel()
     {
         InitializeComponent();
 
         this.WhenActivated(d =>
         {
+            var tl = TopLevel.GetTopLevel(this);
+            if (tl is null) throw new NullReferenceException();
+            this.topLevel = (Window)tl;
+
             if (this.ConfigType == "new-proj")
                 pages.SelectedIndex = 1;
             else if (this.ConfigType == "open-proj")
@@ -131,6 +137,22 @@ public partial class ConfigurationPanel : ReactiveUserControl<ConfigurationPanel
         var topLevel = (Window)tl;
         interaction.SetOutput(true);
         topLevel.Close(interaction.Input);
+    }
+
+    public async void SetProject(object sender, RoutedEventArgs e)
+    {
+        var retTuple = ViewModel!.TrySetProject();
+        await RaiseModal(retTuple.Message);
+        if (retTuple.Status == 0)
+            pages.SelectedIndex = 4;
+    }
+
+    public async void UseSelectedEvent(object sender, RoutedEventArgs e)
+    {
+        var retTuple = ViewModel!.TryLoadEvent();
+        await RaiseModal(retTuple.Message);
+        if (retTuple.Status == 0)
+            this.topLevel.Close(0);
     }
 
 }

--- a/src/EVTUI/UI/ConfigWindow/ConfigurationPanel/ConfigurationPanelViewModel.cs
+++ b/src/EVTUI/UI/ConfigWindow/ConfigurationPanel/ConfigurationPanelViewModel.cs
@@ -405,7 +405,6 @@ public class ConfigurationPanelViewModel : ViewModelBase
                 HashSet<SimpleEvent> combinedPins = new HashSet<SimpleEvent>(this.Config.ProjectManager.ActiveProject.Events.Pinned);
                 combinedPins.UnionWith(this.Config.ProjectManager.ActiveGame.Events.Pinned);
                 foreach (DisplayableEvent evt in this.ConstructDisplayableEvents(new List<SimpleEvent>(combinedPins), this.Config.ProjectManager.ActiveProject.Events.Pinned, this.Config.ProjectManager.ActiveGame.Events.Pinned))
-                //foreach (DisplayableEvent evt in this.ConstructDisplayableEvents(this.Config.ProjectManager.ActiveProject.Events.Pinned, this.Config.ProjectManager.ActiveProject.Events.Pinned, this.Config.ProjectManager.ActiveGame.Events.Pinned))
                     eventList.Add(evt);
             }
         }

--- a/src/EVTUI/UI/ConfigWindow/ConfigurationPanel/ConfigurationPanelViewModel.cs
+++ b/src/EVTUI/UI/ConfigWindow/ConfigurationPanel/ConfigurationPanelViewModel.cs
@@ -236,10 +236,10 @@ public class ConfigurationPanelViewModel : ViewModelBase
 
         this.WhenAnyValue(x => x.ProjectList).Subscribe(x =>
         {
+            OnPropertyChanged(nameof(ProjectList));
             this.ProjectSelection = null;
             if (this.ProjectList.Count > 0)
                 this.ProjectSelection = this.ProjectList[0];
-            OnPropertyChanged(nameof(ProjectList));
             OnPropertyChanged(nameof(ProjectSelection));
             OnPropertyChanged(nameof(AnyRecentProjects));
             OnPropertyChanged(nameof(NoRecentProjects));
@@ -247,10 +247,10 @@ public class ConfigurationPanelViewModel : ViewModelBase
 
         this.WhenAnyValue(x => x.GameList).Subscribe(x =>
         {
+            OnPropertyChanged(nameof(GameList));
             this.GameSelection = null;
             if (this.GameList.Count > 0)
                 this.GameSelection = this.GameList[0];
-            OnPropertyChanged(nameof(GameList));
             OnPropertyChanged(nameof(GameSelection));
             OnPropertyChanged(nameof(AnyRecentGames));
             OnPropertyChanged(nameof(NoRecentGames));
@@ -258,10 +258,10 @@ public class ConfigurationPanelViewModel : ViewModelBase
 
         this.WhenAnyValue(x => x.EventList).Subscribe(x =>
         {
+            OnPropertyChanged(nameof(EventList));
             this.EventSelection = null;
             if (this.EventList.Count > 0)
                 this.EventSelection = this.EventList[0];
-            OnPropertyChanged(nameof(EventList));
             OnPropertyChanged(nameof(EventSelection));
             OnPropertyChanged(nameof(AnyRecentEvents));
             OnPropertyChanged(nameof(NoRecentEvents));

--- a/src/EVTUI/UI/ConfigWindow/ConfigurationPanel/ConfigurationPanelViewModel.cs
+++ b/src/EVTUI/UI/ConfigWindow/ConfigurationPanel/ConfigurationPanelViewModel.cs
@@ -7,30 +7,135 @@ using ReactiveUI;
 
 namespace EVTUI.ViewModels;
 
-public class DisplayableProject
+public class DisplayableProject : ReactiveObject
 {
-    public DisplayableProject(Project project, int ind)
+    public DisplayableProject(DataManager config, int ind)
     {
-        Name     = project.Mutable.Name;
-        GamePath = project.Immutable.Game.Path;
-        ModPath  = project.Immutable.Mod.Path;
+        Project project = config.AllProjects[ind];
+        Config   = config;
+        _name     = project.Name;
+        _notes   = project.Notes;
+        GamePath = project.Game;
+        ModPath  = project.Mod.Path;
         Ind      = ind;
     }
 
-    public string Name     { get; set; }
+    private DataManager Config;
+
+    private string _name;
+    public string Name
+    {
+        get => _name;
+        set
+        {
+            this.RaiseAndSetIfChanged(ref _name, value);
+            this.Config.ProjectManager.SetProjectName(this.Ind, _name);
+        }
+    }
+
+    private string _notes;
+    public string Notes
+    {
+        get => _notes;
+        set
+        {
+            this.RaiseAndSetIfChanged(ref _notes, value);
+            this.Config.ProjectManager.SetProjectNotes(this.Ind, _notes);
+        }
+    }
+
     public string GamePath { get; set; }
     public string ModPath  { get; set; }
     public int    Ind      { get; set; }
 }
 
-public class DisplayableDirectory
+public class DisplayableGame : ReactiveObject
 {
-    public DisplayableDirectory(string directory)
+    public DisplayableGame(DataManager config, int ind)
     {
-        Directory = directory;
+        GameSettings game = config.AllGames[ind];
+        Config = config;
+        Type   = game.Type;
+        _notes = game.Notes;
+        Path   = game.Path;
+        Ind    = ind;
     }
 
-    public string Directory { get; set; }
+    private DataManager Config;
+
+    public string Type  { get; set; }
+
+    private string _notes;
+    public string Notes
+    {
+        get => _notes;
+        set
+        {
+            this.RaiseAndSetIfChanged(ref _notes, value);
+            this.Config.ProjectManager.SetGameNotes(this.Ind, _notes);
+        }
+    }
+
+    public string Path  { get; set; }
+    public int    Ind   { get; set; }
+}
+
+public class DisplayableEvent : ReactiveObject
+{
+    //public DisplayableEvent(DataManager config, int gameind, int projectind, int majorid, int minorid)
+    public DisplayableEvent(DataManager config, GameSettings game, Project project, int majorid, int minorid)
+    {
+        this.Game = game;
+        this.Proj = project;
+        //GameSettings game = config.AllGames[gameind];
+        //Project project = config.AllProjects[projectind];
+        Config  = config;
+        MajorId = majorid;
+        MinorId = minorid;
+        foreach (ExpandedEvent evt in game.Events.Notes)
+            if (evt.MajorId == majorid && evt.MinorId == minorid)
+                _gameNotes  = evt.Text;
+        if (!(project is null))
+            foreach (ExpandedEvent evt in project.Events.Notes)
+                if (evt.MajorId == majorid && evt.MinorId == minorid)
+                    _projNotes  = evt.Text;
+    }
+
+    private DataManager Config;
+
+    public int    MajorId { get; set; }
+    public int    MinorId { get; set; }
+
+    private string _gameNotes;
+    public string GameNotes
+    {
+        get => _gameNotes;
+        set
+        {
+            this.RaiseAndSetIfChanged(ref _gameNotes, value);
+            this.Config.ProjectManager.SetGameEventNotes(this.Game, this.MajorId, this.MinorId, _gameNotes);
+        }
+    }
+
+    private string _projNotes;
+    public string ProjNotes
+    {
+        get => _projNotes;
+        set
+        {
+            if (!(this.Proj is null))
+            {
+                this.RaiseAndSetIfChanged(ref _projNotes, value);
+                this.Config.ProjectManager.SetProjectEventNotes(this.Proj, this.MajorId, this.MinorId, _projNotes);
+            }
+        }
+    }
+
+    //public int GameInd { get; set; }
+    //public int ProjInd { get; set; }
+    private GameSettings Game;
+    private Project      Proj;
+
 }
 
 public class ConfigurationPanelViewModel : ViewModelBase
@@ -39,42 +144,38 @@ public class ConfigurationPanelViewModel : ViewModelBase
     ////////////////////////////
     // *** PUBLIC MEMBERS *** //
     ////////////////////////////
-    public DataManager Config;
+    public DataManager Config { get; }
     public string      ConfigType;
 
-    public HashSet<string> CpkDirSet;
-    public HashSet<string> ModDirSet;
+    public NewProjectConfig newProjectConfig { get; set; }
 
-    public string CpkPath;
-    public string DisplayCPKPath { get => (this.CpkPath is null) ? "(none)" : this.CpkPath; }
-
-    public string? ModPath;
-    public string DisplayModPath { get => (this.ModPath is null) ? "(none)" : this.ModPath; }
+    public string DisplayCPKPath { get => (this.newProjectConfig.GamePath is null) ? "(none)" : this.newProjectConfig.GamePath; }
+    public string DisplayModPath { get => (this.newProjectConfig.ModPath is null) ? "(none)" : this.newProjectConfig.ModPath; }
 
     // all but the name are just placeholders for now
-    public string ModName   { get; set; } = "";
+    /*public string ModName   { get; set; } = "";
     public string ModType   { get; set; } = "Reloaded";
     public string GameType  { get; set; } = "P5R PC (Steam)";
     public bool   UseAwbEmu { get; set; } = false;
     public bool   UseBfEmu  { get; set; } = false;
-    public bool   UseBgmEmu { get; set; } = false;
-    public List<String> ModLoadOrder { get; set; } = new List<string>(["<PRIMARY_MOD_PLACEHOLDER>"]);
+    public bool   UseRyo    { get; set; } = false;
+    public List<String> ModLoadOrder { get; set; } = new List<string>(["<PRIMARY_MOD_PLACEHOLDER>"]);*/
 
     ////////////////////////////////
     // *** OBSERVABLE MEMBERS *** //
     ////////////////////////////////
-    public ObservableCollection<DisplayableDirectory> CpkDirList      { get; }
-    public DisplayableDirectory                       CpkDirSelection { get; set; }
-    public bool AnyRecentCpkDirs { get => (!(this.CpkDirList is null) && this.CpkDirList.Count > 0); }
-    public bool NoRecentCpkDirs { get { return !this.AnyRecentCpkDirs; } }
+    public ObservableCollection<DisplayableGame> GameList      { get; }
+    public DisplayableGame                       GameSelection { get; set; }
+    public bool AnyRecentGames { get => (!(this.GameList is null) && this.GameList.Count > 0); }
+    public bool NoRecentGames  { get { return !this.AnyRecentGames; } }
 
     public ObservableCollection<DisplayableProject> ProjectList      { get; }
     public DisplayableProject                       ProjectSelection { get; set; }
     public bool AnyRecentProjects { get => (this.Config.AllProjects.Count > 0); }
     public bool NoRecentProjects { get => !this.AnyRecentProjects; }
 
-    private ObservableCollection<Event> _eventList;
-    public ObservableCollection<Event> EventList
+    private ObservableCollection<DisplayableEvent> _eventList;
+    public ObservableCollection<DisplayableEvent> EventList
     {
         get => _eventList;
         set => this.RaiseAndSetIfChanged(ref _eventList, value);
@@ -82,14 +183,24 @@ public class ConfigurationPanelViewModel : ViewModelBase
     public bool AnyRecentEvents { get => (!(this.EventList is null) && this.EventList.Count > 0); }
     public bool NoRecentEvents  { get => !this.AnyRecentEvents; }
 
-    private Event _eventSelection;
-    public Event EventSelection
+    private DisplayableEvent _eventSelection;
+    public DisplayableEvent EventSelection
     {
         get => _eventSelection;
         set => this.RaiseAndSetIfChanged(ref _eventSelection, value);
     }
     public int? EventMajorId { get; set; } = 0;
     public int? EventMinorId { get; set; } = 0;
+
+    public bool ProjectLoaded { get => this.Config.ProjectLoaded; }
+
+    public ObservableCollection<string> EventCollections { get; } = new ObservableCollection<string>{"Recent Events", "Pinned Events", "All Events"};
+    private string _selectedCollection = "Recent Events";
+    public string SelectedCollection
+    {
+        get => _selectedCollection;
+        set => this.RaiseAndSetIfChanged(ref _selectedCollection, value);
+    }
 
     ////////////////////////////
     // *** PUBLIC METHODS *** //
@@ -99,45 +210,28 @@ public class ConfigurationPanelViewModel : ViewModelBase
         this.Config = dataManager;
         this.ConfigType = configtype;
 
-        this.ModDirSet = new HashSet<string>();
-        foreach (Project project in this.Config.AllProjects)
-            this.ModDirSet.Add(project.Immutable.Mod.Path);
-
         this.ProjectList = new ObservableCollection<DisplayableProject>();
-        this.CpkDirList = new ObservableCollection<DisplayableDirectory>();
-        _eventList = new ObservableCollection<Event>();
+        this.GameList    = new ObservableCollection<DisplayableGame>();
+        _eventList = new ObservableCollection<DisplayableEvent>();
 
         if (this.ConfigType == "open-proj")
         {
             this.Config.ReadOnly = false;
             for (int i=0; i<this.Config.AllProjects.Count; i++)
-                this.ProjectList.Add(new DisplayableProject(this.Config.AllProjects[i], i));
+                this.ProjectList.Add(new DisplayableProject(this.Config, i));
+                //this.ProjectList.Add(new DisplayableProject(this.Config.AllProjects[i], i));
         }
         else
         {
+            this.newProjectConfig = new NewProjectConfig();
             if (this.ConfigType == "new-proj")
                 this.Config.ReadOnly = false;
             else if (this.ConfigType == "read-only")
                 this.Config.ReadOnly = true;
-            // I was originally splitting the project vs. read-only CPK histories, but eh
-            // ...it's just more convenient to always show both in any recent files tables
-            this.CpkDirSet = new HashSet<string>();
-            foreach (Project project in this.Config.AllProjects)
-            {
-                if (!(this.CpkDirSet.Contains(project.Immutable.Game.Path)))
-                {
-                    this.CpkDirList.Add(new DisplayableDirectory(project.Immutable.Game.Path));
-                    this.CpkDirSet.Add(project.Immutable.Game.Path);
-                }
-            }
-            foreach (string cpkDir in this.Config.AllReadOnlyCPKs)
-            {
-                if (!(this.CpkDirSet.Contains(cpkDir)))
-                {
-                    this.CpkDirList.Add(new DisplayableDirectory(cpkDir));
-                    this.CpkDirSet.Add(cpkDir);
-                }
-            }
+            //foreach (GameSettings game in this.Config.AllGames)
+            //    this.GameList.Add(new DisplayableGame(game.Type, game.Notes, game.Path));
+            for (int i=0; i<this.Config.AllGames.Count; i++)
+                this.GameList.Add(new DisplayableGame(this.Config, i));
         }
 
         this.WhenAnyValue(x => x.ProjectList).Subscribe(x =>
@@ -151,15 +245,15 @@ public class ConfigurationPanelViewModel : ViewModelBase
             OnPropertyChanged(nameof(NoRecentProjects));
         });
 
-        this.WhenAnyValue(x => x.CpkDirList).Subscribe(x =>
+        this.WhenAnyValue(x => x.GameList).Subscribe(x =>
         {
-            this.CpkDirSelection = null;
-            if (this.CpkDirList.Count > 0)
-                this.CpkDirSelection = this.CpkDirList[0];
-            OnPropertyChanged(nameof(CpkDirList));
-            OnPropertyChanged(nameof(CpkDirSelection));
-            OnPropertyChanged(nameof(AnyRecentCpkDirs));
-            OnPropertyChanged(nameof(NoRecentCpkDirs));
+            this.GameSelection = null;
+            if (this.GameList.Count > 0)
+                this.GameSelection = this.GameList[0];
+            OnPropertyChanged(nameof(GameList));
+            OnPropertyChanged(nameof(GameSelection));
+            OnPropertyChanged(nameof(AnyRecentGames));
+            OnPropertyChanged(nameof(NoRecentGames));
         });
 
         this.WhenAnyValue(x => x.EventList).Subscribe(x =>
@@ -172,9 +266,11 @@ public class ConfigurationPanelViewModel : ViewModelBase
             OnPropertyChanged(nameof(AnyRecentEvents));
             OnPropertyChanged(nameof(NoRecentEvents));
         });
-        if (this.ConfigType == "read-only")
-            this.EventList = new ObservableCollection<Event>(this.Config.AllReadOnlyEvents);
+        // TODO
+        //if (this.ConfigType == "read-only")
+        //    this.EventList = new ObservableCollection<DisplayableEvent>(this.Config.AllUserEvents);
 
+        this.WhenAnyValue(x => x.SelectedCollection).Subscribe(x => this.DisplayEvents());
     }
     
     public bool TrySetCPKs(string cpkdir)
@@ -183,8 +279,11 @@ public class ConfigurationPanelViewModel : ViewModelBase
         if (cpks.Count <= 0)
             return false;
 
-        this.CpkPath =  cpkdir;
-        OnPropertyChanged(nameof(DisplayCPKPath));
+        if (!(newProjectConfig is null))
+        {
+            this.newProjectConfig.GamePath = cpkdir;
+            OnPropertyChanged(nameof(DisplayCPKPath));
+        }
         this.Config.CpkList = cpks;
         return true;
     }
@@ -193,50 +292,56 @@ public class ConfigurationPanelViewModel : ViewModelBase
     {
         if (this.Config.ProjectManager.ModPathAlreadyUsed(maybedir))
             return (1, "Selected mod directory is used in another project and cannot be reused.");
-        this.ModPath = maybedir;
+        this.newProjectConfig.ModPath = maybedir;
         OnPropertyChanged(nameof(DisplayModPath));
         return (0, null);
     }
 
     public (int Status, string Message) TryCreateProject()
     {
-        if (this.ModName is null || this.ModName == "")
+        if (this.newProjectConfig.Name is null || this.newProjectConfig.Name == "")
             return (1, "Project name hasn't been set.");
-        if (this.CpkPath is null || this.CpkPath == "")
+        if (this.newProjectConfig.GamePath is null || this.newProjectConfig.GamePath == "")
             return (1, "Game (CPK) folder hasn't been set.");
-        if (this.ModPath is null || this.ModPath == "")
+        if (this.newProjectConfig.ModPath is null || this.newProjectConfig.ModPath == "")
             return (1, "Mod folder hasn't been set.");
 
-        bool projectSuccess = this.Config.ProjectManager.TryUpdateProjects(this.CpkPath, this.GameType, this.ModPath, this.ModType, this.ModName, (new Dictionary<string, bool>{{"AWBEmulator", this.UseAwbEmu}, {"BFEmulator", this.UseBfEmu}, {"BGME", this.UseBgmEmu}}), this.ModLoadOrder);
+        //bool projectSuccess = this.Config.ProjectManager.TryUpdateProjects(this.CpkPath, this.GameType, this.ModPath, this.ModType, this.ModName, (new Dictionary<string, bool>{{"AWBEmulator", this.UseAwbEmu}, {"BFEmulator", this.UseBfEmu}, {"Ryo", this.UseRyo}}), this.ModLoadOrder);
+        bool projectSuccess = this.Config.ProjectManager.TryUpdateProjects(this.newProjectConfig);
         if (!projectSuccess)
             return (1, "Something is wrong with the provided folders. Project could not be created.");
 
         this.Config.LoadProject(0);
 
-        if (this.Config.ActiveProject is null)
+        if (this.Config.ProjectManager.ActiveProject is null)
             return (1, "Failed to load project for some reason.");
 
-        this.EventList = new ObservableCollection<Event>(this.Config.ActiveProject.History.Events);
-        return (0, $"Loaded project \"{this.Config.ActiveProject.Mutable.Name}\"!");
+        return (0, $"Loaded project \"{this.Config.ProjectManager.ActiveProject.Name}\"!");
     }
 
-    public (int Status, string Message) TryUseCPKDir(string cpkdir)
+    public (int Status, string Message) TryUseCPKDir(string cpkdir, string gametype)
     {
         if (cpkdir is null)
         {
-            if (this.CpkDirSelection is null)
+            if (this.GameSelection is null)
                 return (1, "No CPK folder selected.");
-            if (this.CpkDirSelection.Directory is null)
+            if (this.GameSelection.Path is null)
                 return (1, "CPK folder selection is invalid.");
-            cpkdir = this.CpkDirSelection.Directory;
+            //cpkdir = this.GameSelection.Path;
+            //gametype = this.GameSelection.Type;
+            //notes = this.GameSelection.Notes;
+            if (!this.TrySetCPKs(this.GameSelection.Path))
+                return (1, "No CPKs in selected folder.");
+            if (this.Config.ReadOnly)
+                this.Config.ProjectManager.LoadGameReadOnly(this.GameSelection.Ind);
         }
-
-        if (!this.TrySetCPKs(cpkdir))
-            return (1, "No CPKs in selected folder.");
-
-        // set CpkPath...?
-        if (this.Config.ReadOnly)
-            this.Config.ProjectManager.UpdateReadOnlyCPKs(cpkdir);
+        else
+        {
+            if (!this.TrySetCPKs(cpkdir))
+                return (1, "No CPKs in selected folder.");
+            if (this.Config.ReadOnly)
+                this.Config.ProjectManager.UpdateReadOnlyCPKs(cpkdir, gametype, "");
+        }
         return (0, null);
     }
 
@@ -251,11 +356,39 @@ public class ConfigurationPanelViewModel : ViewModelBase
             return (1, "No CPKs in selected folder.");
 
         this.Config.LoadProject(this.ProjectSelection.Ind);
-        if (this.Config.ActiveProject is null)
+        if (this.Config.ProjectManager.ActiveProject is null)
             return (1, "No project loaded.");
 
-        this.EventList = new ObservableCollection<Event>(this.Config.ActiveProject.History.Events);
-        return (0, $"Loaded project \"{this.Config.ActiveProject.Mutable.Name}\"!");
+        return (0, $"Loaded project \"{this.Config.ProjectManager.ActiveProject.Name}\"!");
+    }
+
+    public void DisplayEvents()
+    {
+        OnPropertyChanged(nameof(ProjectLoaded));
+
+        ObservableCollection<DisplayableEvent> eventList = new ObservableCollection<DisplayableEvent>();
+        if (this.SelectedCollection == "All Events")
+            foreach (var evt in this.Config.ListAllEvents())
+                eventList.Add(new DisplayableEvent(this.Config, this.Config.ProjectManager.ActiveGame, this.Config.ProjectManager.ActiveProject, evt.MajorId, evt.MinorId));
+        else if (!(this.Config.ProjectManager.ActiveProject is null))
+        {
+            if (this.SelectedCollection == "Recent Events")
+                foreach (SimpleEvent evt in this.Config.ProjectManager.ActiveProject.Events.Recent)
+                    eventList.Add(new DisplayableEvent(this.Config, this.Config.ProjectManager.ActiveGame, this.Config.ProjectManager.ActiveProject, evt.MajorId, evt.MinorId));
+            else if (this.SelectedCollection == "Pinned Events")
+                foreach (SimpleEvent evt in this.Config.ProjectManager.ActiveProject.Events.Pinned)
+                    eventList.Add(new DisplayableEvent(this.Config, this.Config.ProjectManager.ActiveGame, this.Config.ProjectManager.ActiveProject, evt.MajorId, evt.MinorId));
+        }
+        else if (!(this.Config.ProjectManager.ActiveGame is null))
+        {
+            if (this.SelectedCollection == "Recent Events")
+                foreach (SimpleEvent evt in this.Config.ProjectManager.ActiveGame.Events.Recent)
+                    eventList.Add(new DisplayableEvent(this.Config, this.Config.ProjectManager.ActiveGame, this.Config.ProjectManager.ActiveProject, evt.MajorId, evt.MinorId));
+            else if (this.SelectedCollection == "Pinned Events")
+                foreach (SimpleEvent evt in this.Config.ProjectManager.ActiveGame.Events.Pinned)
+                    eventList.Add(new DisplayableEvent(this.Config, this.Config.ProjectManager.ActiveGame, this.Config.ProjectManager.ActiveProject, evt.MajorId, evt.MinorId));
+        }
+        this.EventList = eventList;
     }
 
     public (int Status, string Message) TryLoadEvent(bool fromSelection)

--- a/src/EVTUI/UI/ConfigWindow/ConfigurationPanel/ConfigurationPanelViewModel.cs
+++ b/src/EVTUI/UI/ConfigWindow/ConfigurationPanel/ConfigurationPanelViewModel.cs
@@ -82,13 +82,10 @@ public class DisplayableGame : ReactiveObject
 
 public class DisplayableEvent : ReactiveObject
 {
-    //public DisplayableEvent(DataManager config, int gameind, int projectind, int majorid, int minorid)
     public DisplayableEvent(DataManager config, GameSettings game, Project project, int majorid, int minorid)
     {
         this.Game = game;
         this.Proj = project;
-        //GameSettings game = config.AllGames[gameind];
-        //Project project = config.AllProjects[projectind];
         Config  = config;
         MajorId = majorid;
         MinorId = minorid;
@@ -103,8 +100,8 @@ public class DisplayableEvent : ReactiveObject
 
     private DataManager Config;
 
-    public int    MajorId { get; set; }
-    public int    MinorId { get; set; }
+    public int MajorId { get; set; }
+    public int MinorId { get; set; }
 
     private string _gameNotes;
     public string GameNotes
@@ -131,8 +128,6 @@ public class DisplayableEvent : ReactiveObject
         }
     }
 
-    //public int GameInd { get; set; }
-    //public int ProjInd { get; set; }
     private GameSettings Game;
     private Project      Proj;
 
@@ -151,15 +146,6 @@ public class ConfigurationPanelViewModel : ViewModelBase
 
     public string DisplayCPKPath { get => (this.newProjectConfig.GamePath is null) ? "(none)" : this.newProjectConfig.GamePath; }
     public string DisplayModPath { get => (this.newProjectConfig.ModPath is null) ? "(none)" : this.newProjectConfig.ModPath; }
-
-    // all but the name are just placeholders for now
-    /*public string ModName   { get; set; } = "";
-    public string ModType   { get; set; } = "Reloaded";
-    public string GameType  { get; set; } = "P5R PC (Steam)";
-    public bool   UseAwbEmu { get; set; } = false;
-    public bool   UseBfEmu  { get; set; } = false;
-    public bool   UseRyo    { get; set; } = false;
-    public List<String> ModLoadOrder { get; set; } = new List<string>(["<PRIMARY_MOD_PLACEHOLDER>"]);*/
 
     ////////////////////////////////
     // *** OBSERVABLE MEMBERS *** //
@@ -219,7 +205,6 @@ public class ConfigurationPanelViewModel : ViewModelBase
             this.Config.ReadOnly = false;
             for (int i=0; i<this.Config.AllProjects.Count; i++)
                 this.ProjectList.Add(new DisplayableProject(this.Config, i));
-                //this.ProjectList.Add(new DisplayableProject(this.Config.AllProjects[i], i));
         }
         else
         {
@@ -228,8 +213,6 @@ public class ConfigurationPanelViewModel : ViewModelBase
                 this.Config.ReadOnly = false;
             else if (this.ConfigType == "read-only")
                 this.Config.ReadOnly = true;
-            //foreach (GameSettings game in this.Config.AllGames)
-            //    this.GameList.Add(new DisplayableGame(game.Type, game.Notes, game.Path));
             for (int i=0; i<this.Config.AllGames.Count; i++)
                 this.GameList.Add(new DisplayableGame(this.Config, i));
         }
@@ -266,9 +249,6 @@ public class ConfigurationPanelViewModel : ViewModelBase
             OnPropertyChanged(nameof(AnyRecentEvents));
             OnPropertyChanged(nameof(NoRecentEvents));
         });
-        // TODO
-        //if (this.ConfigType == "read-only")
-        //    this.EventList = new ObservableCollection<DisplayableEvent>(this.Config.AllUserEvents);
 
         this.WhenAnyValue(x => x.SelectedCollection).Subscribe(x => this.DisplayEvents());
     }
@@ -306,7 +286,6 @@ public class ConfigurationPanelViewModel : ViewModelBase
         if (this.newProjectConfig.ModPath is null || this.newProjectConfig.ModPath == "")
             return (1, "Mod folder hasn't been set.");
 
-        //bool projectSuccess = this.Config.ProjectManager.TryUpdateProjects(this.CpkPath, this.GameType, this.ModPath, this.ModType, this.ModName, (new Dictionary<string, bool>{{"AWBEmulator", this.UseAwbEmu}, {"BFEmulator", this.UseBfEmu}, {"Ryo", this.UseRyo}}), this.ModLoadOrder);
         bool projectSuccess = this.Config.ProjectManager.TryUpdateProjects(this.newProjectConfig);
         if (!projectSuccess)
             return (1, "Something is wrong with the provided folders. Project could not be created.");
@@ -327,9 +306,6 @@ public class ConfigurationPanelViewModel : ViewModelBase
                 return (1, "No CPK folder selected.");
             if (this.GameSelection.Path is null)
                 return (1, "CPK folder selection is invalid.");
-            //cpkdir = this.GameSelection.Path;
-            //gametype = this.GameSelection.Type;
-            //notes = this.GameSelection.Notes;
             if (!this.TrySetCPKs(this.GameSelection.Path))
                 return (1, "No CPKs in selected folder.");
             if (this.Config.ReadOnly)

--- a/src/EVTUI/UI/EditorWindow/AudioPanel/AudioPanelViewModel.cs
+++ b/src/EVTUI/UI/EditorWindow/AudioPanel/AudioPanelViewModel.cs
@@ -57,6 +57,6 @@ public class AudioPanelViewModel : ViewModelBase
     public void PlaySelectedTrack()
     {
         if (this.TrackSelection != null)
-            this.Config.AudioManager.PlayCueTrack(this.TrackSelection.CueId, this.TrackSelection.TrackIndex);
+            this.Config.AudioManager.PlayCueTrack(this.TrackSelection.CueId, this.TrackSelection.TrackIndex, this.Config.ProjectManager.AdxKey);
     }
 }

--- a/src/EVTUI/UI/EditorWindow/EditorWindow.axaml.cs
+++ b/src/EVTUI/UI/EditorWindow/EditorWindow.axaml.cs
@@ -1,5 +1,8 @@
 using System;
+using System.ComponentModel;
 using Avalonia.Controls;
+
+using EVTUI.ViewModels;
 
 namespace EVTUI.Views;
 
@@ -8,5 +11,11 @@ public partial class EditorWindow : Window
     public EditorWindow()
     {
         InitializeComponent();
+        this.Closing += this.ClearCache;
+    }
+
+    public void ClearCache(object? sender, CancelEventArgs args)
+    {
+        ((EditorWindowViewModel)DataContext).ClearCache();
     }
 }

--- a/src/EVTUI/UI/EditorWindow/EditorWindowViewModel.cs
+++ b/src/EVTUI/UI/EditorWindow/EditorWindowViewModel.cs
@@ -1,4 +1,8 @@
-﻿namespace EVTUI.ViewModels;
+﻿using System;
+
+using EVTUI;
+
+namespace EVTUI.ViewModels;
 
 public class EditorWindowViewModel : ViewModelBase
 {
@@ -18,6 +22,11 @@ public class EditorWindowViewModel : ViewModelBase
         this.Config          = dataManager;
         this.audioPanelVM    = new AudioPanelViewModel(this.Config);
         this.timelinePanelVM = new TimelinePanelViewModel(this.Config);
+    }
+
+    public void ClearCache()
+    {
+        this.Config.ClearCache();
     }
 
 }

--- a/src/EVTUI/UI/EditorWindow/TimelinePanel/CommandViewModels/MAA_.cs
+++ b/src/EVTUI/UI/EditorWindow/TimelinePanel/CommandViewModels/MAA_.cs
@@ -13,10 +13,10 @@ public class MAA_ : Generic
 
         this.PrimaryAnimPreviewVM = new GFDRenderingPanelViewModel();
         this.SecondaryAnimPreviewVM = new GFDRenderingPanelViewModel();
-        List<string> assetPaths = config.EventManager.GetAssetPaths(this.Command.ObjectId, config.CpkList, config.ModPath);
+        List<string> assetPaths = config.EventManager.GetAssetPaths(this.Command.ObjectId, config.CpkList, config.VanillaExtractionPath);
         if (assetPaths.Count > 0)
         {
-            List<string> animPaths = config.EventManager.GetAnimPaths(this.Command.ObjectId, true, true, config.CpkList, config.ModPath);
+            List<string> animPaths = config.EventManager.GetAnimPaths(this.Command.ObjectId, true, true, config.CpkList, config.VanillaExtractionPath);
             if (animPaths.Count > 0)
             {
                 this.PrimaryAnimPreviewVM.sceneManager.QueuedLoads.Enqueue((assetPaths[0], animPaths[0], this.CommandData.PrimaryAnimationIndex, true));

--- a/src/EVTUI/UI/EditorWindow/TimelinePanel/CommandViewModels/MAB_.cs
+++ b/src/EVTUI/UI/EditorWindow/TimelinePanel/CommandViewModels/MAB_.cs
@@ -21,18 +21,18 @@ public class MAB_ : Generic
 
         this.PrimaryAnimPreviewVM = new GFDRenderingPanelViewModel();
         this.SecondaryAnimPreviewVM = new GFDRenderingPanelViewModel();
-        List<string> assetPaths = config.EventManager.GetAssetPaths(this.Command.ObjectId, config.CpkList, config.ModPath);
+        List<string> assetPaths = config.EventManager.GetAssetPaths(this.Command.ObjectId, config.CpkList, config.VanillaExtractionPath);
         if (assetPaths.Count > 0)
         {
-            if (this.HasPrimaryAnimation.Value)
-            {
-                List<string> primaryAnimPaths = config.EventManager.GetAnimPaths(this.Command.ObjectId, !this.PrimaryAnimationFromSecondaryFile.Value, false, config.CpkList, config.ModPath);
+            //if (this.HasPrimaryAnimation.Value)
+            //{
+                List<string> primaryAnimPaths = config.EventManager.GetAnimPaths(this.Command.ObjectId, !this.PrimaryAnimationFromSecondaryFile.Value, false, config.CpkList, config.VanillaExtractionPath);
                 if (primaryAnimPaths.Count > 0)
                     this.PrimaryAnimPreviewVM.sceneManager.QueuedLoads.Enqueue((assetPaths[0], primaryAnimPaths[0], this.CommandData.PrimaryAnimationIndex, false));
-            }
+            //}
             if (this.HasSecondaryAnimation.Value)
             {
-                List<string> secondaryAnimPaths = config.EventManager.GetAnimPaths(this.Command.ObjectId, !this.SecondaryAnimationFromSecondaryFile.Value, false, config.CpkList, config.ModPath);
+                List<string> secondaryAnimPaths = config.EventManager.GetAnimPaths(this.Command.ObjectId, !this.SecondaryAnimationFromSecondaryFile.Value, false, config.CpkList, config.VanillaExtractionPath);
                 if (secondaryAnimPaths.Count > 0)
                     this.SecondaryAnimPreviewVM.sceneManager.QueuedLoads.Enqueue((assetPaths[0], secondaryAnimPaths[0], this.CommandData.SecondaryAnimationIndex, false));
             }

--- a/src/EVTUI/UI/EditorWindow/TimelinePanel/CommandViewModels/MAB_.cs
+++ b/src/EVTUI/UI/EditorWindow/TimelinePanel/CommandViewModels/MAB_.cs
@@ -24,12 +24,12 @@ public class MAB_ : Generic
         List<string> assetPaths = config.EventManager.GetAssetPaths(this.Command.ObjectId, config.CpkList, config.VanillaExtractionPath);
         if (assetPaths.Count > 0)
         {
-            //if (this.HasPrimaryAnimation.Value)
-            //{
+            if (this.HasPrimaryAnimation.Value)
+            {
                 List<string> primaryAnimPaths = config.EventManager.GetAnimPaths(this.Command.ObjectId, !this.PrimaryAnimationFromSecondaryFile.Value, false, config.CpkList, config.VanillaExtractionPath);
                 if (primaryAnimPaths.Count > 0)
                     this.PrimaryAnimPreviewVM.sceneManager.QueuedLoads.Enqueue((assetPaths[0], primaryAnimPaths[0], this.CommandData.PrimaryAnimationIndex, false));
-            //}
+            }
             if (this.HasSecondaryAnimation.Value)
             {
                 List<string> secondaryAnimPaths = config.EventManager.GetAnimPaths(this.Command.ObjectId, !this.SecondaryAnimationFromSecondaryFile.Value, false, config.CpkList, config.VanillaExtractionPath);

--- a/src/EVTUI/UI/EditorWindow/TimelinePanel/CommandViewModels/MAtO.cs
+++ b/src/EVTUI/UI/EditorWindow/TimelinePanel/CommandViewModels/MAtO.cs
@@ -18,12 +18,12 @@ public class MAtO : Generic
         this.ZRotation = new NumEntryField("Z", this.Editable, this.CommandData.Rotation[2], -180, 180, 0.1);
 
         this.ParentModelPreviewVM = new GFDRenderingPanelViewModel();
-        List<string> parentAssetPaths = config.EventManager.GetAssetPaths(this.Command.ObjectId, config.CpkList, config.ModPath);
+        List<string> parentAssetPaths = config.EventManager.GetAssetPaths(this.Command.ObjectId, config.CpkList, config.VanillaExtractionPath);
         if (parentAssetPaths.Count > 0)
             this.ParentModelPreviewVM.sceneManager.QueuedLoads.Enqueue((parentAssetPaths[0], null, null, false));
 
         this.ChildModelPreviewVM = new GFDRenderingPanelViewModel();
-        List<string> childAssetPaths = config.EventManager.GetAssetPaths(this.CommandData.ChildObjectId, config.CpkList, config.ModPath);
+        List<string> childAssetPaths = config.EventManager.GetAssetPaths(this.CommandData.ChildObjectId, config.CpkList, config.VanillaExtractionPath);
         if (childAssetPaths.Count > 0)
             this.ChildModelPreviewVM.sceneManager.QueuedLoads.Enqueue((childAssetPaths[0], null, null, false));
     }

--- a/src/EVTUI/UI/EditorWindow/TimelinePanel/CommandViewModels/MAt_.cs
+++ b/src/EVTUI/UI/EditorWindow/TimelinePanel/CommandViewModels/MAt_.cs
@@ -19,12 +19,12 @@ public class MAt_ : Generic
         this.ZRotation = new NumRangeField("Z", this.Editable, this.CommandData.Rotation[2], -180, 180, 0.1);
 
         this.ParentModelPreviewVM = new GFDRenderingPanelViewModel();
-        List<string> parentAssetPaths = config.EventManager.GetAssetPaths(this.Command.ObjectId, config.CpkList, config.ModPath);
+        List<string> parentAssetPaths = config.EventManager.GetAssetPaths(this.Command.ObjectId, config.CpkList, config.VanillaExtractionPath);
         if (parentAssetPaths.Count > 0)
             this.ParentModelPreviewVM.sceneManager.QueuedLoads.Enqueue((parentAssetPaths[0], null, null, false));
 
         this.ChildModelPreviewVM = new GFDRenderingPanelViewModel();
-        List<string> childAssetPaths = config.EventManager.GetAssetPaths(this.CommandData.ChildObjectId, config.CpkList, config.ModPath);
+        List<string> childAssetPaths = config.EventManager.GetAssetPaths(this.CommandData.ChildObjectId, config.CpkList, config.VanillaExtractionPath);
         if (childAssetPaths.Count > 0)
             this.ChildModelPreviewVM.sceneManager.QueuedLoads.Enqueue((childAssetPaths[0], null, null, false));
     }

--- a/src/EVTUI/UI/EditorWindow/TimelinePanel/CommandViewModels/MDt_.cs
+++ b/src/EVTUI/UI/EditorWindow/TimelinePanel/CommandViewModels/MDt_.cs
@@ -19,12 +19,12 @@ public class MDt_ : Generic
         this.ZRotation = new NumRangeField("Z", this.Editable, this.CommandData.Rotation[2], -180, 180, 0.1);
 
         this.ParentModelPreviewVM = new GFDRenderingPanelViewModel();
-        List<string> parentAssetPaths = config.EventManager.GetAssetPaths(this.Command.ObjectId, config.CpkList, config.ModPath);
+        List<string> parentAssetPaths = config.EventManager.GetAssetPaths(this.Command.ObjectId, config.CpkList, config.VanillaExtractionPath);
         if (parentAssetPaths.Count > 0)
             this.ParentModelPreviewVM.sceneManager.QueuedLoads.Enqueue((parentAssetPaths[0], null, null, false));
 
         this.ChildModelPreviewVM = new GFDRenderingPanelViewModel();
-        List<string> childAssetPaths = config.EventManager.GetAssetPaths(this.CommandData.ChildObjectId, config.CpkList, config.ModPath);
+        List<string> childAssetPaths = config.EventManager.GetAssetPaths(this.CommandData.ChildObjectId, config.CpkList, config.VanillaExtractionPath);
         if (childAssetPaths.Count > 0)
             this.ChildModelPreviewVM.sceneManager.QueuedLoads.Enqueue((childAssetPaths[0], null, null, false));
     }

--- a/src/EVTUI/UI/EditorWindow/TimelinePanel/CommandViewModels/MSD_.cs
+++ b/src/EVTUI/UI/EditorWindow/TimelinePanel/CommandViewModels/MSD_.cs
@@ -19,10 +19,10 @@ public class MSD_ : Generic
         this.EndFrame = new NumEntryField("End at Frame", this.Editable, this.CommandData.LastFrameInd, 0, null, 1);
 
         this.ModelPreviewVM = new GFDRenderingPanelViewModel();
-        List<string> assetPaths = config.EventManager.GetAssetPaths(this.Command.ObjectId, config.CpkList, config.ModPath);
+        List<string> assetPaths = config.EventManager.GetAssetPaths(this.Command.ObjectId, config.CpkList, config.VanillaExtractionPath);
         if (assetPaths.Count > 0)
         {
-            List<string> animPaths = config.EventManager.GetAnimPaths(this.Command.ObjectId, true, false, config.CpkList, config.ModPath);
+            List<string> animPaths = config.EventManager.GetAnimPaths(this.Command.ObjectId, true, false, config.CpkList, config.VanillaExtractionPath);
             if (animPaths.Count > 0)
                 this.ModelPreviewVM.sceneManager.QueuedLoads.Enqueue((assetPaths[0], animPaths[0], this.CommandData.AnimationIndex, false));
             else

--- a/src/EVTUI/UI/EditorWindow/TimelinePanel/CommandViewModels/Msg_.cs
+++ b/src/EVTUI/UI/EditorWindow/TimelinePanel/CommandViewModels/Msg_.cs
@@ -20,26 +20,29 @@ public class Msg_ : Generic
         int msgIndex = config.ScriptManager.GetTurnIndex(this.CommandData.MessageMajorId, this.CommandData.MessageMinorId, this.CommandData.MessageSubId);
         string msgId = config.ScriptManager.GetTurnName(msgIndex);
         this.MessageID = new StringSelectionField("Message ID", this.Editable, msgId, config.ScriptManager.MsgNames);
-        if (config.ScriptManager.MsgNames.Contains(this.MessageID.Choice))
-            this.MessageBlock = new MessagePreview(config, msgIndex);
-        this.WhenAnyValue(x => x.MessageID.Choice).Subscribe(x =>
+        if (!(config.ScriptManager.ActiveBMD is null))
         {
-            int newMsgIndex = config.ScriptManager.GetTurnIndex(this.MessageID.Choice);
-            if (config.ScriptManager.MsgNames.Contains(config.ScriptManager.GetTurnName(newMsgIndex)))
-                this.MessageBlock = new MessagePreview(config, newMsgIndex);
-        });
+            if (config.ScriptManager.MsgNames.Contains(this.MessageID.Choice))
+                this.MessageBlock = new MessagePreview(config, msgIndex);
+            this.WhenAnyValue(x => x.MessageID.Choice).Subscribe(x =>
+            {
+                int newMsgIndex = config.ScriptManager.GetTurnIndex(this.MessageID.Choice);
+                if (config.ScriptManager.MsgNames.Contains(config.ScriptManager.GetTurnName(newMsgIndex)))
+                    this.MessageBlock = new MessagePreview(config, newMsgIndex);
+            });
 
-        int selIndex = config.ScriptManager.GetTurnIndex(this.CommandData.SelectMajorId, this.CommandData.SelectMinorId, this.CommandData.SelectSubId);
-        string selId = config.ScriptManager.GetTurnName(selIndex);
-        this.SelectionID = new StringSelectionField("Selection ID", this.Editable, selId, config.ScriptManager.SelNames);
-        if (config.ScriptManager.SelNames.Contains(this.SelectionID.Choice))
-            _selectionBlock = new SelectionPreview(config, selIndex);
-        this.WhenAnyValue(x => x.SelectionID.Choice).Subscribe(x =>
-        {
-            int newSelIndex = config.ScriptManager.GetTurnIndex(this.SelectionID.Choice);
-            if (config.ScriptManager.SelNames.Contains(config.ScriptManager.GetTurnName(newSelIndex)))
-                this.SelectionBlock = new SelectionPreview(config, newSelIndex);
-        });
+            int selIndex = config.ScriptManager.GetTurnIndex(this.CommandData.SelectMajorId, this.CommandData.SelectMinorId, this.CommandData.SelectSubId);
+            string selId = config.ScriptManager.GetTurnName(selIndex);
+            this.SelectionID = new StringSelectionField("Selection ID", this.Editable, selId, config.ScriptManager.SelNames);
+            if (config.ScriptManager.SelNames.Contains(this.SelectionID.Choice))
+                _selectionBlock = new SelectionPreview(config, selIndex);
+            this.WhenAnyValue(x => x.SelectionID.Choice).Subscribe(x =>
+            {
+                int newSelIndex = config.ScriptManager.GetTurnIndex(this.SelectionID.Choice);
+                if (config.ScriptManager.SelNames.Contains(config.ScriptManager.GetTurnName(newSelIndex)))
+                    this.SelectionBlock = new SelectionPreview(config, newSelIndex);
+            });
+        }
     }
 
     public BoolChoiceField      HasMessage   { get; set; }

--- a/src/EVTUI/UI/EditorWindow/TimelinePanel/TimelinePanelViewModel.cs
+++ b/src/EVTUI/UI/EditorWindow/TimelinePanel/TimelinePanelViewModel.cs
@@ -173,7 +173,8 @@ public class Timeline
         {
             string code = dataManager.EventManager.EventCommands[j].CommandCode;
             int i = dataManager.EventManager.EventCommands[j].FrameStart;
-            if (i < this.Frames.Count)
+            //Console.WriteLine(i);
+            if (i >= 0 && i < this.Frames.Count)
             {
                 int k = this.Frames[i].Commands.Count;
                 this.Frames[i].Commands.Add(new CommandPointer(code, false, j, k));
@@ -255,7 +256,7 @@ public class TimelinePanelViewModel : ViewModelBase
         if (this.Config.AudioManager.AcbByType[source].Count > 0)
         {
             this.Config.AudioManager.ActiveACB = this.Config.AudioManager.AcbByType[source][0];
-            this.Config.AudioManager.PlayCueTrack((uint)cueId, trackIndex);
+            this.Config.AudioManager.PlayCueTrack((uint)cueId, trackIndex, this.Config.ProjectManager.AdxKey);
         }
     }
 

--- a/src/EVTUI/UI/EditorWindow/TimelinePanel/TimelinePanelViewModel.cs
+++ b/src/EVTUI/UI/EditorWindow/TimelinePanel/TimelinePanelViewModel.cs
@@ -173,7 +173,6 @@ public class Timeline
         {
             string code = dataManager.EventManager.EventCommands[j].CommandCode;
             int i = dataManager.EventManager.EventCommands[j].FrameStart;
-            //Console.WriteLine(i);
             if (i >= 0 && i < this.Frames.Count)
             {
                 int k = this.Frames[i].Commands.Count;

--- a/src/EVTUI/UI/MainWindow/LandingPage/LandingPage.axaml.cs
+++ b/src/EVTUI/UI/MainWindow/LandingPage/LandingPage.axaml.cs
@@ -56,7 +56,7 @@ public partial class LandingPage : ReactiveUserControl<LandingPageViewModel>
         if (configtype == "read-only")
             editorWindowView.Title = $"EVTUI: {config.ActiveEventId} (read-only)";
         else
-            editorWindowView.Title = $"EVTUI: {config.ActiveEventId} ({config.ActiveProject.Mutable.Name})";
+            editorWindowView.Title = $"EVTUI: {config.ActiveEventId} ({config.ProjectManager.ActiveProject.Name})";
 
         res = await ((Window)editorWindowView).ShowDialog<int?>(topLevel);
         config.Reset();

--- a/src/EVTUI/UI/Utilities/MessageBox.axaml
+++ b/src/EVTUI/UI/Utilities/MessageBox.axaml
@@ -4,8 +4,8 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="EVTUI.Views.MessageBox">
-  <StackPanel  Margin="20" VerticalAlignment="Center">
-   <TextBlock Grid.Row="0" Grid.Column="0" HorizontalAlignment="Center" Margin="20" Name="ModalText"/>
-   <Button Content="OK" Grid.Row="1" Grid.Column="0" Click="ClickHandler" HorizontalAlignment="Center" Margin="20"/>
+  <StackPanel Margin="20" VerticalAlignment="Center">
+    <TextBlock Name="ModalText" HorizontalAlignment="Center" Margin="20"/>
+    <Button Name="OKButton" Content="OK" Click="ClickHandler" Background="{DynamicResource SystemAccentColor}" HorizontalAlignment="Center" Padding="10" Margin="20" Focusable="True"/>
   </StackPanel>
 </UserControl>

--- a/src/EVTUI/UI/Utilities/MessageBox.axaml.cs
+++ b/src/EVTUI/UI/Utilities/MessageBox.axaml.cs
@@ -1,10 +1,8 @@
+using System;
+
 using Avalonia;
 using Avalonia.Controls;
-using Avalonia.Markup.Xaml;
-
 using Avalonia.Interactivity;
-
-using System;
 
 namespace EVTUI.Views;
 
@@ -21,9 +19,8 @@ public partial class MessageBox : UserControl
 
     public void OnInitialized(object? sender, EventArgs e)
     {
-        var modalText = this.FindControl<TextBlock>("ModalText");
-        if (modalText is null) throw new NullReferenceException();
-        modalText.Text = this.text;
+        this.ModalText.Text = this.text;
+        this.OKButton.AttachedToVisualTree += (s, e) => this.OKButton.Focus();
     }
 
     public void ClickHandler(object sender, RoutedEventArgs args)


### PR DESCRIPTION
### Various improvements to the startup / config / user data flow, including...
- Can't run multiple instances of the app (important for user data hygiene)
- Files are extracted into the EVTUI app data directory, which is cleared regularly (will implement actual saving of important files into the user's mod directory in a later PR)
- Generally updating the config codebehind to match with more recent MVVM style (as seen in e.g. the timeline view code)
- Got rid of a few extra button presses during project/event opening to make it smoother
  - First lines in tables / some buttons have automatic focus, again to save clicks
- Extra tables for viewing events to open in the setup, including Recent/Pinned/All, where before there was just Recent events
  - Events can be pinned/unpinned per project or per game
- Ability to handle both P5R and the P5 early dev builds, hopefully moving toward more generalized code / configurability overall
  - Game selection now available via dropdown in config
- Changes to user data structure to accommodate the above
- Small fixes to timeline view to stop it from crashing on certain ill-formed events
- Malformed user data results in just starting fresh (rather than erroring out)

### For a future PR:
- Condense more of the project creation config
  - (get rid of tabs...?)
- Deal with malformed/outdated user data format in a better way
  - (like giving users the choice for whether to erase their user data instead of just doing it)
- Make game path configuration more robust
  - (e.g., in project creation, if you try to change the game type after selecting the path... you can't)
  - (also it should also be possible to delete game configs, but doing so might also delete the projects that use them, etc.)