### PR TITLE
Actually save/load modded files

### DIFF
--- a/src/gui/ConfigWindow/ConfigurationPanel/ConfigurationPanel.axaml.cs
+++ b/src/gui/ConfigWindow/ConfigurationPanel/ConfigurationPanel.axaml.cs
@@ -43,27 +43,6 @@ public partial class ConfigurationPanel : ReactiveUserControl<ConfigurationPanel
         });
     }
 
-    // If we need to pop boxes like this from multiple places, we should add this to
-    // a View base class or something.
-    public async Task<int> RaiseModal(string text)
-    {
-        Window sampleWindow =
-            new Window 
-            { 
-                SizeToContent = SizeToContent.WidthAndHeight,
-                WindowStartupLocation = WindowStartupLocation.CenterOwner
-            };
-        sampleWindow.Content = new MessageBox(text);
-
-        // Launch window and get a return code to distinguish how the window
-        // was closed.
-        int? res = await sampleWindow.ShowDialog<int?>(this.topLevel);
-        if (res is null)
-            return 1;
-        else
-            return (int)res;
-    }
-
     private void GoToEventPage()
     {
         ViewModel!.DisplayEvents();
@@ -87,7 +66,7 @@ public partial class ConfigurationPanel : ReactiveUserControl<ConfigurationPanel
         {
             var retTuple = ViewModel!.TrySetModDir(dirs[0].Path.AbsolutePath);
             if (retTuple.Status != 0)
-                await RaiseModal(retTuple.Message);
+                await Utils.RaiseModal(this.topLevel, retTuple.Message);
         }
     }
 
@@ -97,7 +76,7 @@ public partial class ConfigurationPanel : ReactiveUserControl<ConfigurationPanel
         if (retTuple.Status == 0)
             this.GoToEventPage();
         else
-            await RaiseModal(retTuple.Message);
+            await Utils.RaiseModal(this.topLevel, retTuple.Message);
     }
 
     ////////////////////////////
@@ -108,7 +87,7 @@ public partial class ConfigurationPanel : ReactiveUserControl<ConfigurationPanel
     {
         var retTuple = ViewModel!.TryUseCPKDir(null, null);
         if (retTuple.Status != 0)
-            await RaiseModal(retTuple.Message);
+            await Utils.RaiseModal(this.topLevel, retTuple.Message);
         else if (ViewModel!.ConfigType == "read-only")
             this.GoToEventPage();
     }
@@ -126,7 +105,7 @@ public partial class ConfigurationPanel : ReactiveUserControl<ConfigurationPanel
         {
             var retTuple = ViewModel!.TryUseCPKDir(dirs[0].Path.AbsolutePath, ViewModel!.newProjectConfig.GameType);
             if (retTuple.Status != 0)
-                await RaiseModal(retTuple.Message);
+                await Utils.RaiseModal(this.topLevel, retTuple.Message);
             else if (ViewModel!.ConfigType == "read-only")
                 this.GoToEventPage();
         }
@@ -145,7 +124,7 @@ public partial class ConfigurationPanel : ReactiveUserControl<ConfigurationPanel
             this.GoToEventPage();
         }
         else
-            await RaiseModal(retTuple.Message);
+            await Utils.RaiseModal(this.topLevel, retTuple.Message);
     }
 
     //////////////////////////////////
@@ -158,7 +137,7 @@ public partial class ConfigurationPanel : ReactiveUserControl<ConfigurationPanel
         if (retTuple.Status == 0)
             this.topLevel.Close(0);
         else
-            await RaiseModal(retTuple.Message);
+            await Utils.RaiseModal(this.topLevel, retTuple.Message);
     }
 
     public async void UseEnteredEvent(object sender, RoutedEventArgs e)
@@ -167,7 +146,7 @@ public partial class ConfigurationPanel : ReactiveUserControl<ConfigurationPanel
         if (retTuple.Status == 0)
             this.topLevel.Close(0);
         else
-            await RaiseModal(retTuple.Message);
+            await Utils.RaiseModal(this.topLevel, retTuple.Message);
     }
 
 }

--- a/src/gui/EditorWindow/EditorWindow.axaml
+++ b/src/gui/EditorWindow/EditorWindow.axaml
@@ -11,11 +11,23 @@
         Width="1200" Height="800" WindowStartupLocation="CenterScreen"
         Title="EVTUI">
 
-  <TabControl Margin="5">
+  <DockPanel>
+  <Menu DockPanel.Dock="Top" HorizontalAlignment="Right">
+    <MenuItem Header="Save">
+      <MenuItem Header="Save all" Click="SaveMod" />
+      <MenuItem Header="Save EVT" Click="SaveMod" Name="EVT" />
+      <MenuItem Header="Save ECS" Click="SaveMod" Name="ECS" />
+    </MenuItem>
+    <MenuItem Header="Reload">
+      <MenuItem Header="Reload all" />
+      <MenuItem Header="Reload EVT" />
+      <MenuItem Header="Reload ECS" />
+    </MenuItem>
+  </Menu>
+  <TabControl Margin="5" DockPanel.Dock="Bottom">
     <TabItem Header="Editors">
       <TabControl Margin="5">
         <TabItem Header="Timeline">
-          <!--TextBlock Text="This is the Timeline Editor tab." /-->
           <views:TimelinePanel DataContext="{Binding timelinePanelVM}" Padding="10"/>
         </TabItem>
         <TabItem Header="Dialogue">
@@ -43,5 +55,6 @@
       <TextBlock Text="This is the Render tab." />
     </TabItem>
   </TabControl>
+  </DockPanel>
 
 </Window>

--- a/src/gui/EditorWindow/EditorWindow.axaml
+++ b/src/gui/EditorWindow/EditorWindow.axaml
@@ -13,7 +13,7 @@
 
   <DockPanel>
   <Menu DockPanel.Dock="Top" HorizontalAlignment="Right">
-    <MenuItem Header="Save">
+    <MenuItem Header="Save" IsEnabled="{Binding !Config.ReadOnly}">
       <MenuItem Header="Save all" Click="SaveMod" />
       <MenuItem Header="Save EVT" Click="SaveMod" Name="EVT" />
       <MenuItem Header="Save ECS" Click="SaveMod" Name="ECS" />

--- a/src/gui/EditorWindow/EditorWindow.axaml.cs
+++ b/src/gui/EditorWindow/EditorWindow.axaml.cs
@@ -1,6 +1,7 @@
 using System;
 using System.ComponentModel;
 using Avalonia.Controls;
+using Avalonia.Interactivity;
 
 using EVTUI.ViewModels;
 
@@ -17,5 +18,18 @@ public partial class EditorWindow : Window
     public void ClearCache(object? sender, CancelEventArgs args)
     {
         ((EditorWindowViewModel)DataContext).ClearCache();
+    }
+
+    public async void SaveMod(object? sender, RoutedEventArgs args)
+    {
+        try
+        {
+            ((EditorWindowViewModel)DataContext).SaveMod(((MenuItem)sender).Name);
+            await Utils.RaiseModal(this, "Saved successfully!");
+        }
+        catch (Exception ex)
+        {
+            await Utils.RaiseModal(this, "Failed to save due to unhandled exception: '" + ex.ToString() + "'");
+        }
     }
 }

--- a/src/gui/EditorWindow/EditorWindowViewModel.cs
+++ b/src/gui/EditorWindow/EditorWindowViewModel.cs
@@ -29,4 +29,22 @@ public class EditorWindowViewModel : ViewModelBase
         this.Config.ClearCache();
     }
 
+    public void SaveMod(string which)
+    {
+        switch (which)
+        {
+            case "EVT":
+                this.Config.SaveModdedFiles(true, false);
+                break;
+            case "ECS":
+                this.Config.SaveModdedFiles(false, true);
+                break;
+            case null:
+                this.Config.SaveModdedFiles(true, true);
+                break;
+            default:
+                break;
+        }
+    }
+
 }

--- a/src/gui/EditorWindow/EditorWindowViewModel.cs
+++ b/src/gui/EditorWindow/EditorWindowViewModel.cs
@@ -10,8 +10,8 @@ public class EditorWindowViewModel : ViewModelBase
     ////////////////////////////
     // *** PUBLIC MEMBERS *** //
     ////////////////////////////
-    public DataManager Config;
-    public AudioPanelViewModel audioPanelVM { get; }
+    public DataManager            Config          { get; }
+    public AudioPanelViewModel    audioPanelVM    { get; }
     public TimelinePanelViewModel timelinePanelVM { get; }
 
     ////////////////////////////

--- a/src/gui/Utilities/MessageBox.cs
+++ b/src/gui/Utilities/MessageBox.cs
@@ -1,0 +1,30 @@
+using System.Threading.Tasks;
+using Avalonia.Controls;
+
+namespace EVTUI.Views;
+
+public partial class Utils
+{
+
+    // If we need to pop boxes like this from multiple places, we should add this to
+    // a View base class or something.
+    public static async Task<int> RaiseModal(Window tl, string text)
+    {
+        Window sampleWindow =
+            new Window 
+            { 
+                SizeToContent = SizeToContent.WidthAndHeight,
+                WindowStartupLocation = WindowStartupLocation.CenterOwner
+            };
+        sampleWindow.Content = new MessageBox(text);
+
+        // Launch window and get a return code to distinguish how the window
+        // was closed.
+        int? res = await sampleWindow.ShowDialog<int?>(tl);
+        if (res is null)
+            return 1;
+        else
+            return (int)res;
+    }
+
+}

--- a/src/lib/AudioManager.cs
+++ b/src/lib/AudioManager.cs
@@ -135,7 +135,6 @@ public class AudioManager
             this.ActiveACB = null;
         foreach (string key in this.AcbByType.Keys)
             this.AcbByType[key].Sort((x, y) => x.CompareTo(y));
-        Console.WriteLine(this.AcbByType["Voice"].Count);
     }
 
     public void PlayCueTrack(uint cueId, int trackIndex, ulong keyCode)

--- a/src/lib/DataManager.cs
+++ b/src/lib/DataManager.cs
@@ -130,16 +130,21 @@ public class DataManager
 
     public void SaveModdedFiles(bool evt, bool ecs)
     {
+        if (this.ReadOnly)
+            return;
+
         if (evt)
         {
-            string moddedEvtPath = Path.Combine(this.ProjectManager.ModdedFileDir, this.EventManager.EvtPath.Substring((this.VanillaExtractionPath.Length+1), this.EventManager.EvtPath.Length-(this.VanillaExtractionPath.Length+1)));
+            string baseEvtPath = this.EventManager.EvtPath.Substring((this.VanillaExtractionPath.Length+1), this.EventManager.EvtPath.Length-(this.VanillaExtractionPath.Length+1));
+            string moddedEvtPath = Path.Combine(this.ProjectManager.ModdedFileDir, baseEvtPath);
             (new FileInfo(moddedEvtPath)).Directory.Create();
             this.EventManager.SaveEVT(moddedEvtPath);
         }
 
         if (ecs)
         {
-            string moddedEcsPath = Path.Combine(this.ProjectManager.ModdedFileDir, this.EventManager.EcsPath.Substring((this.VanillaExtractionPath.Length+1), this.EventManager.EcsPath.Length-(this.VanillaExtractionPath.Length+1)));
+            string baseEcsPath = this.EventManager.EcsPath.Substring((this.VanillaExtractionPath.Length+1), this.EventManager.EcsPath.Length-(this.VanillaExtractionPath.Length+1));
+            string moddedEcsPath = Path.Combine(this.ProjectManager.ModdedFileDir, baseEcsPath);
             (new FileInfo(moddedEcsPath)).Directory.Create();
             this.EventManager.SaveECS(moddedEcsPath);
         }

--- a/src/lib/DataManager.cs
+++ b/src/lib/DataManager.cs
@@ -86,7 +86,7 @@ public class DataManager
         if (!this.ReadOnly && !this.ProjectLoaded)
             return false;
 
-        bool success = this.EventManager.Load(this.CpkList, $"E{majorId:000}_{minorId:000}", this.VanillaExtractionPath, this.ProjectManager.CpkDecryptionFunctionName);
+        bool success = this.EventManager.Load(this.CpkList, $"E{majorId:000}_{minorId:000}", this.VanillaExtractionPath, this.ProjectManager.ModdedFileDir, this.ProjectManager.CpkDecryptionFunctionName);
         if (success)
             this.ProjectManager.LoadEvent(majorId, minorId);
         this.EventLoaded = success;
@@ -135,18 +135,24 @@ public class DataManager
 
         if (evt)
         {
-            string baseEvtPath = this.EventManager.EvtPath.Substring((this.VanillaExtractionPath.Length+1), this.EventManager.EvtPath.Length-(this.VanillaExtractionPath.Length+1));
-            string moddedEvtPath = Path.Combine(this.ProjectManager.ModdedFileDir, baseEvtPath);
-            (new FileInfo(moddedEvtPath)).Directory.Create();
-            this.EventManager.SaveEVT(moddedEvtPath);
+            if (!this.EventManager.EvtPath.StartsWith(this.ProjectManager.ModdedFileDir))
+            {
+                string baseEvtPath = this.EventManager.EvtPath.Substring((this.VanillaExtractionPath.Length+1), this.EventManager.EvtPath.Length-(this.VanillaExtractionPath.Length+1));
+                this.EventManager.EvtPath = Path.Combine(this.ProjectManager.ModdedFileDir, baseEvtPath);
+            }
+            (new FileInfo(this.EventManager.EvtPath)).Directory.Create();
+            this.EventManager.SaveEVT();
         }
 
         if (ecs)
         {
-            string baseEcsPath = this.EventManager.EcsPath.Substring((this.VanillaExtractionPath.Length+1), this.EventManager.EcsPath.Length-(this.VanillaExtractionPath.Length+1));
-            string moddedEcsPath = Path.Combine(this.ProjectManager.ModdedFileDir, baseEcsPath);
-            (new FileInfo(moddedEcsPath)).Directory.Create();
-            this.EventManager.SaveECS(moddedEcsPath);
+            if (!this.EventManager.EcsPath.StartsWith(this.ProjectManager.ModdedFileDir))
+            {
+                string baseEcsPath = this.EventManager.EcsPath.Substring((this.VanillaExtractionPath.Length+1), this.EventManager.EcsPath.Length-(this.VanillaExtractionPath.Length+1));
+                this.EventManager.EcsPath = Path.Combine(this.ProjectManager.ModdedFileDir, baseEcsPath);
+            }
+            (new FileInfo(this.EventManager.EcsPath)).Directory.Create();
+            this.EventManager.SaveECS();
         }
     }
 

--- a/src/lib/DataManager.cs
+++ b/src/lib/DataManager.cs
@@ -128,4 +128,21 @@ public class DataManager
         CPKExtract.ClearDirectory(this.VanillaExtractionPath);
     }
 
+    public void SaveModdedFiles(bool evt, bool ecs)
+    {
+        if (evt)
+        {
+            string moddedEvtPath = Path.Combine(this.ProjectManager.ModdedFileDir, this.EventManager.EvtPath.Substring((this.VanillaExtractionPath.Length+1), this.EventManager.EvtPath.Length-(this.VanillaExtractionPath.Length+1)));
+            (new FileInfo(moddedEvtPath)).Directory.Create();
+            this.EventManager.SaveEVT(moddedEvtPath);
+        }
+
+        if (ecs)
+        {
+            string moddedEcsPath = Path.Combine(this.ProjectManager.ModdedFileDir, this.EventManager.EcsPath.Substring((this.VanillaExtractionPath.Length+1), this.EventManager.EcsPath.Length-(this.VanillaExtractionPath.Length+1)));
+            (new FileInfo(moddedEcsPath)).Directory.Create();
+            this.EventManager.SaveECS(moddedEcsPath);
+        }
+    }
+
 }

--- a/src/lib/EventManager.cs
+++ b/src/lib/EventManager.cs
@@ -29,6 +29,8 @@ public class EventManager
     ////////////////////////////
     // *** PUBLIC MEMBERS *** //
     ///////////////.////////////
+    public string       EvtPath;
+    public string       EcsPath;
     public List<(string ACB, string? AWB)> AcwbPaths;
     public List<string> BfPaths;
     public List<string> BmdPaths;
@@ -45,11 +47,13 @@ public class EventManager
         if (cpkEVTContents is null)
             return false;
 
+        this.EvtPath = cpkEVTContents.Value.evtPath;
         this.SerialEvent = new EVT();
-        this.SerialEvent.Read(cpkEVTContents.Value.evtPath);
+        this.SerialEvent.Read(this.EvtPath);
 
+        this.EcsPath = cpkEVTContents.Value.ecsPath;
         this.SerialEventSounds = new ECS();
-        this.SerialEventSounds.Read(cpkEVTContents.Value.ecsPath);
+        this.SerialEventSounds.Read(this.EcsPath);
 
         // the DataManager will pass these to the AudioManager
         this.AcwbPaths = new List<(string ACB, string? AWB)>();
@@ -76,6 +80,9 @@ public class EventManager
         this.SerialEventSounds         = null;
         this.CpkDecryptionFunctionName = null;
     }
+
+    public void SaveEVT(string path) { this.SerialEvent.Write(path); }
+    public void SaveECS(string path) { this.SerialEventSounds.Write(path); }
 
     public int EventDuration { get { return this.SerialEvent.TotalFrame; } }
     public SerialCommand[] EventCommands { get { return this.SerialEvent.Commands; } }

--- a/src/lib/EventManager.cs
+++ b/src/lib/EventManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.IO;
 
 namespace EVTUI;
 
@@ -38,12 +39,12 @@ public class EventManager
     ////////////////////////////
     // *** PUBLIC METHODS *** //
     ////////////////////////////
-    public bool Load(List<string> cpkList, string evtid, string targetdir, string cpkDecryptionFunctionName)
+    public bool Load(List<string> cpkList, string evtid, string vanillaDir, string moddedDir, string cpkDecryptionFunctionName)
     {
         this.Clear();
         this.CpkDecryptionFunctionName = cpkDecryptionFunctionName;
 
-        CpkEVTContents? cpkEVTContents = CPKExtract.ExtractEVTFiles(cpkList, evtid, targetdir, this.CpkDecryptionFunctionName);
+        CpkEVTContents? cpkEVTContents = CPKExtract.ExtractEVTFiles(cpkList, evtid, vanillaDir, moddedDir, this.CpkDecryptionFunctionName);
         if (cpkEVTContents is null)
             return false;
 
@@ -81,8 +82,8 @@ public class EventManager
         this.CpkDecryptionFunctionName = null;
     }
 
-    public void SaveEVT(string path) { this.SerialEvent.Write(path); }
-    public void SaveECS(string path) { this.SerialEventSounds.Write(path); }
+    public void SaveEVT() { this.SerialEvent.Write(this.EvtPath); }
+    public void SaveECS() { this.SerialEventSounds.Write(this.EcsPath); }
 
     public int EventDuration { get { return this.SerialEvent.TotalFrame; } }
     public SerialCommand[] EventCommands { get { return this.SerialEvent.Commands; } }

--- a/src/lib/ProjectManager.cs
+++ b/src/lib/ProjectManager.cs
@@ -67,6 +67,7 @@ public class ProjectManager
     public GameSettings? ActiveGame;
     public Project?      ActiveProject;
     public SimpleEvent?  ActiveEvent;
+    public string        ModdedFileDir;
 
     public ulong AdxKey { get => (this.ActiveGame is null) ? 0 : ProjectManager.KeyCodes[this.ActiveGame.Type]; }
     public string CpkDecryptionFunctionName { get => (this.ActiveGame is null || !this.ActiveGame.Type.StartsWith("P5R")) ? null : "P5R"; }
@@ -149,6 +150,12 @@ public class ProjectManager
 
         Trace.Assert(!(this.ActiveGame is null) && !(this.ActiveProject is null), "Game specified for project doesn't exist.");
 
+        this.ModdedFileDir = this.ActiveProject.Mod.Path;
+        if (this.ActiveProject.Frameworks.ContainsKey("P5REssentials") && this.ActiveProject.Frameworks["P5REssentials"])
+            this.ModdedFileDir = Path.Combine(this.ModdedFileDir, "P5REssentials", "CPK");
+        if (!Directory.Exists(this.ModdedFileDir))
+            Directory.CreateDirectory(this.ModdedFileDir);
+
         this.SaveUserCache();
     }
 
@@ -166,6 +173,7 @@ public class ProjectManager
 
         this.ActiveGame = this.UserData.Games[0];
         this.ActiveProject = null;
+        this.ModdedFileDir = null;
     }
 
     public void LoadEvent(int majorId, int minorId)


### PR DESCRIPTION
Don't ask me why it took until now to implement this part....

### Includes:
- Adds a menu in the top right of the editor window for saving EVT/ECS/both
- Saves it in the canonical `P5REssentials/` structure if said framework is enabled for the project
- Saving isn't available in read-only mode (obviously)
- Load from modded files, too, when opening an already-modded event

### For a future PR:
- Be able to handle other mod dependencies (and differentiate relevant files from each, somehow, maybe)