### PR TITLE
Fixes for BF/BMD compiling

### DIFF
--- a/src/lib/DataManager.cs
+++ b/src/lib/DataManager.cs
@@ -110,12 +110,12 @@ public class DataManager
 
     public string CompileMessage(string fileBase)
     {
-        return this.ScriptManager.CompileMessage(this.VanillaExtractionPath, fileBase);
+        return this.ScriptManager.CompileMessage(this.WorkingPath, fileBase);
     }
 
     public string CompileScript(string fileBase)
     {
-        return this.ScriptManager.CompileScript(this.VanillaExtractionPath, fileBase);
+        return this.ScriptManager.CompileScript(this.WorkingPath, fileBase);
     }
 
     public List<string> GetCPKsFromPath(string? directoryPath)

--- a/src/lib/FileIO/CPKExtract.cs
+++ b/src/lib/FileIO/CPKExtract.cs
@@ -131,6 +131,7 @@ public static class CPKExtract
         var retval = new CpkEVTContents();
         Regex eventPattern = new Regex($"[\\\\/]{eventId}([\\\\/\\.]|_SE)", RegexOptions.IgnoreCase);
         bool evtFound = false;
+        Char[] dirSeps = new Char[] { '/', '\\' };
 
         KnownDecryptionFunction decryptionFunctionIndex;
         InPlaceDecryptionFunction decryptionFunction = null;
@@ -151,7 +152,7 @@ public static class CPKExtract
 
             Parallel.For(0, files.Length, x =>
             {
-                string inCpkPath = Path.Combine(files[x].Directory ?? "", files[x].FileName);
+                string inCpkPath = Path.Combine(files[x].Directory ?? "", Path.Combine(files[x].FileName.Split(dirSeps)));
                 string outputPath = Path.GetFullPath(Path.Combine(OutputFolder, Path.GetFileName(CpkPath), inCpkPath));
 
                 // hmmmokay right now the behavior is to skip extracting if it exists

--- a/src/lib/ScriptManager.cs
+++ b/src/lib/ScriptManager.cs
@@ -469,7 +469,9 @@ public class ScriptManager
             MessageScript msgScript = new MessageScript(FormatVersion.Version1BigEndian, this.Encoding);
             bool success = compiler.TryCompile(this.ScriptTexts["BMD"][fileBase][".msg"], out msgScript);
             this.BMDFiles[fileBase] = new BMD();
-            this.BMDFiles[fileBase].FromBytes(((MemoryStream)msgScript.ToBinary().ToStream()).ToArray());
+            byte[] newBytes = ((MemoryStream)msgScript.ToBinary().ToStream()).ToArray();
+            this.BMDFiles[fileBase].FromBytes(newBytes);
+            File.WriteAllBytes(outPath+".BMD", newBytes);
         }
         catch (Exception ex)
         {
@@ -521,14 +523,18 @@ public class ScriptManager
 
         try
         {
-            FlowScriptCompiler compiler = new FlowScriptCompiler(FlowFormatVersion.Unknown);
+            // TODO: should detect the version from the vanilla extracted file...?
+            // orrrr output version just depends on game type?
+            FlowScriptCompiler compiler = new FlowScriptCompiler(FlowFormatVersion.Version1BigEndian);
             compiler.Encoding = this.Encoding;
             compiler.Library = LibraryLookup.GetLibrary(this.GameName);
             compiler.AddListener(listener);
-            FlowScript flowScript = new FlowScript(FlowFormatVersion.Unknown);
+            FlowScript flowScript = new FlowScript(FlowFormatVersion.Version1BigEndian);
             bool success = compiler.TryCompile(this.ScriptTexts["BF"][fileBase][".flow"], out flowScript);
+            byte[] newBytes = ((MemoryStream)flowScript.ToBinary().ToStream()).ToArray();
             //this.BFFiles[fileBase] = new BF();
-            //this.BFFiles[fileBase].FromBytes(((MemoryStream)flowScript.ToBinary().ToStream()).ToArray());
+            //this.BFFiles[fileBase].FromBytes(newBytes);
+            File.WriteAllBytes(outPath+".BF", newBytes);
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
BF/BMD compiling wasn't working properly on Windows and/or without emus turned on. Fixes include:

- File path sanitization
- Compiling the correct copy of the scripts
- Actually saving compiled BF/BMD binaries (lol)
- Setting BF version during compiling