### PR TITLE
Fix for CPK internal paths on Windows

### DIFF
--- a/src/lib/FileIO/CPKExtract.cs
+++ b/src/lib/FileIO/CPKExtract.cs
@@ -152,7 +152,7 @@ public static class CPKExtract
 
             Parallel.For(0, files.Length, x =>
             {
-                string inCpkPath = Path.Combine(files[x].Directory ?? "", Path.Combine(files[x].FileName.Split(dirSeps)));
+                string inCpkPath = Path.Combine(Path.Combine(files[x].Directory.Split(dirSeps)) ?? "", files[x].FileName);
                 string outputPath = Path.GetFullPath(Path.Combine(OutputFolder, Path.GetFileName(CpkPath), inCpkPath));
 
                 // hmmmokay right now the behavior is to skip extracting if it exists


### PR DESCRIPTION
https://github.com/DarkPsydeOfTheMoon/EVTUI/pull/14 was incorrect in its fix for CPK-internal file paths; this corrects that. It seems like the issue was mostly cosmetic and didn't actually prevent things from working, so that's good I guess, but the inconsistent file separators was annoying to look at.