### PR TITLE
Basics editor tab corrections & completeness

### DIFF
--- a/src/gui/EditorWindow/AssetsPanel/AssetsPanel.axaml
+++ b/src/gui/EditorWindow/AssetsPanel/AssetsPanel.axaml
@@ -166,6 +166,7 @@
         <TextBox
           AcceptsReturn="true"
           Text="{Binding Text}"
+          MaxLength="{Binding MaxLength}"
           IsEnabled="{Binding Editable}"/>
       </StackPanel>
     </DataTemplate>

--- a/src/gui/EditorWindow/BasicsPanel/BasicsPanel.axaml
+++ b/src/gui/EditorWindow/BasicsPanel/BasicsPanel.axaml
@@ -63,7 +63,7 @@
     </Style>
     <Style Selector="StackPanel.form">
       <Setter Property="Orientation" Value="Vertical"/>
-      <Setter Property="Margin" Value="5"/>
+      <Setter Property="Margin" Value="20"/>
       <Setter Property="Spacing" Value="10"/>
     </Style>
     <Style Selector="TextBlock.formtitle">
@@ -161,6 +161,7 @@
         <TextBox
           AcceptsReturn="true"
           Text="{Binding Text}"
+          MaxLength="{Binding MaxLength}"
           IsEnabled="{Binding Editable}"/>
       </StackPanel>
     </DataTemplate>
@@ -188,50 +189,42 @@
 
   </UserControl.DataTemplates>
 
-  <DockPanel>
-    <Button
-     Background="{DynamicResource SystemAccentColor}"
-     DockPanel.Dock="Bottom"
-     FontSize="18"
-     HorizontalAlignment="Center"
-     IsEnabled="{Binding Editable}">
-       Apply Changes
-    </Button>
-    <ScrollViewer DockPanel.Dock="Top">
-      <StackPanel Classes="form">
+  <ScrollViewer>
+    <StackPanel Classes="form">
 
-        <TextBlock Classes="formtitle" Text="Labels"/>
-        <Separator Classes="formtitle"/>
-        <ContentControl Content="{Binding MajorID}"/>
-        <ContentControl Content="{Binding MinorID}"/>
-        <ContentControl Content="{Binding Rank}"/>
-        <ContentControl Content="{Binding Level}"/>
+      <TextBlock Classes="formtitle" Text="Labels"/>
+      <Separator Classes="formtitle"/>
+      <ContentControl Content="{Binding MajorID}"/>
+      <ContentControl Content="{Binding MinorID}"/>
+      <ContentControl Content="{Binding Rank}"/>
+      <ContentControl Content="{Binding Level}"/>
 
-        <TextBlock Classes="formtitle" Text="Scripts"/>
-        <Separator Classes="formtitle"/>
-        <ContentControl Content="{Binding EmbedBMD}"/>
-        <ContentControl Content="{Binding EmbedBF}"/>
-        <ContentControl Content="{Binding InitScriptEnabled}"/>
-        <ContentControl Content="{Binding InitScriptIndex}"/>
+      <TextBlock Classes="formtitle" Text="Scripts"/>
+      <Separator Classes="formtitle"/>
+      <ContentControl Content="{Binding EmbedBMD}"/>
+      <ContentControl Content="{Binding BMDPath}" IsVisible="{Binding EmbedBMD.Value}"/>
+      <ContentControl Content="{Binding EmbedBF}"/>
+      <ContentControl Content="{Binding BFPath}" IsVisible="{Binding EmbedBF.Value}"/>
+      <ContentControl Content="{Binding InitScriptEnabled}"/>
+      <ContentControl Content="{Binding InitScriptIndex}" IsVisible="{Binding InitScriptEnabled.Value}"/>
 
-        <TextBlock Classes="formtitle" Text="Cinemascope"/>
-        <Separator Classes="formtitle"/>
-        <ContentControl Content="{Binding CinemascopeEnabled}"/>
-        <ContentControl Content="{Binding CinemascopeAnimationEnabled}"/>
-        <ContentControl Content="{Binding CinemascopeStartingFrame}"/>
+      <TextBlock Classes="formtitle" Text="Cinemascope"/>
+      <Separator Classes="formtitle"/>
+      <ContentControl Content="{Binding CinemascopeEnabled}"/>
+      <ContentControl Content="{Binding CinemascopeAnimationEnabled}" IsVisible="{Binding CinemascopeEnabled.Value}"/>
+      <ContentControl Content="{Binding CinemascopeStartingFrame}" IsVisible="{Binding CinemascopeEnabled.Value}"/>
 
-        <TextBlock Classes="formtitle" Text="ENV"/>
-        <Separator Classes="formtitle"/>
-        <ContentControl Content="{Binding InitEnvAssetID}"/>
-        <ContentControl Content="{Binding DebugEnvAssetID}"/>
+      <TextBlock Classes="formtitle" Text="ENV"/>
+      <Separator Classes="formtitle"/>
+      <ContentControl Content="{Binding InitEnvAssetID}"/>
+      <ContentControl Content="{Binding DebugEnvAssetID}"/>
 
-        <TextBlock Classes="formtitle" Text="Other Flags"/>
-        <Separator Classes="formtitle"/>
-        <ContentControl Content="{Binding UnkFlag1}"/>
-        <ContentControl Content="{Binding UnkFlag2}"/>
+      <TextBlock Classes="formtitle" Text="Other Flags"/>
+      <Separator Classes="formtitle"/>
+      <ContentControl Content="{Binding UnkFlag1}"/>
+      <ContentControl Content="{Binding UnkFlag2}"/>
 
-      </StackPanel>
-    </ScrollViewer>
-  </DockPanel>
+    </StackPanel>
+  </ScrollViewer>
 
 </rxui:ReactiveUserControl>

--- a/src/gui/EditorWindow/BasicsPanel/BasicsPanelViewModel.cs
+++ b/src/gui/EditorWindow/BasicsPanel/BasicsPanelViewModel.cs
@@ -41,6 +41,10 @@ public class BasicsPanelViewModel : ViewModelBase
     public NumEntryField InitEnvAssetID  { get; set; }
     public NumEntryField DebugEnvAssetID { get; set; }
 
+    // paths
+    public StringEntryField BMDPath { get; set; }
+    public StringEntryField BFPath  { get; set; }
+
     public bool Editable { get; set; }
 
     public enum Ranks : byte
@@ -76,23 +80,42 @@ public class BasicsPanelViewModel : ViewModelBase
         this.WhenAnyValue(x => x.Level.Value).Subscribe(x => evt.Level = (byte)x);
 
         // scripts
-        this.EmbedBMD = new BoolChoiceField("Embed BMD in EVT", this.Editable, evt.Flags[12]);
-        this.EmbedBF = new BoolChoiceField("Embed BF in EVT", this.Editable, evt.Flags[14]);
+        this.EmbedBMD = new BoolChoiceField("Use custom BMD path?", this.Editable, evt.Flags[12]);
+        this.BMDPath = new StringEntryField("Custom BMD path", this.Editable, (evt.EventBmdPath is null) ? $"event_data/message/e{(100*(evt.MajorId/100)):000}/e{evt.MajorId:000}_{evt.MinorId:000}.bmd" : evt.EventBmdPath.Replace("\0", ""), 48);
+        this.EmbedBF = new BoolChoiceField("Use custom BF path?", this.Editable, evt.Flags[14]);
+        this.BFPath = new StringEntryField("Custom BF path", this.Editable, (evt.EventBfPath is null) ? $"event_data/message/e{(100*(evt.MajorId/100)):000}/e{evt.MajorId:000}_{evt.MinorId:000}.bf" : evt.EventBfPath.Replace("\0", ""), 48);
         this.InitScriptEnabled = new BoolChoiceField("Enable Init Script", this.Editable, evt.Flags[1]);
         this.InitScriptIndex = new NumEntryField("Init Script Index", this.Editable, (int)evt.InitScriptIndex, 0, 255, 1);
+
+        this.WhenAnyValue(x => x.EmbedBMD.Value).Subscribe(x => evt.Flags[12] = this.EmbedBMD.Value);
+        this.WhenAnyValue(x => x.BMDPath.Text).Subscribe(x => evt.EventBmdPath = this.BMDPath.Text);
+        this.WhenAnyValue(x => x.EmbedBF.Value).Subscribe(x => evt.Flags[14] = this.EmbedBF.Value);
+        this.WhenAnyValue(x => x.BFPath.Text).Subscribe(x => evt.EventBfPath = this.BFPath.Text);
+        this.WhenAnyValue(x => x.InitScriptEnabled.Value).Subscribe(x => evt.Flags[1] = this.InitScriptEnabled.Value);
+        this.WhenAnyValue(x => x.InitScriptIndex.Value).Subscribe(x => evt.InitScriptIndex = (byte)x);
 
         // cinemascope
         this.CinemascopeEnabled = new BoolChoiceField("Enable Cinemascope", this.Editable, evt.Flags[8]);
         this.CinemascopeAnimationEnabled = new BoolChoiceField("Enable Cinemascope Animation", this.Editable, evt.Flags[9]);
         this.CinemascopeStartingFrame = new NumEntryField("Cinemascope Starting Frame", this.Editable, (int)evt.CinemascopeStartingFrame, 0, 9999, 1);
 
+        this.WhenAnyValue(x => x.CinemascopeEnabled.Value).Subscribe(x => evt.Flags[8] = this.CinemascopeEnabled.Value);
+        this.WhenAnyValue(x => x.CinemascopeAnimationEnabled.Value).Subscribe(x => evt.Flags[9] = this.CinemascopeEnabled.Value);
+        this.WhenAnyValue(x => x.CinemascopeStartingFrame.Value).Subscribe(x => evt.CinemascopeStartingFrame = (short)x);
+
         // env
         this.InitEnvAssetID = new NumEntryField("Init ENV ID", this.Editable, (int)evt.InitEnvAssetID, 0, 9999, 1);
         this.DebugEnvAssetID = new NumEntryField("Debug ENV ID", this.Editable, (int)evt.InitDebugEnvAssetID, 0, 9999, 1);
 
+        this.WhenAnyValue(x => x.InitEnvAssetID.Value).Subscribe(x => evt.InitEnvAssetID = (int)x);
+        this.WhenAnyValue(x => x.DebugEnvAssetID.Value).Subscribe(x => evt.InitDebugEnvAssetID = (int)x);
+
         // other flags
         this.UnkFlag1 = new BoolChoiceField("Unknown Flag #1", this.Editable, evt.Flags[6]);
         this.UnkFlag2 = new BoolChoiceField("Unknown Flag #2", this.Editable, evt.Flags[16]);
+
+        this.WhenAnyValue(x => x.UnkFlag1.Value).Subscribe(x => evt.Flags[6] = this.UnkFlag1.Value);
+        this.WhenAnyValue(x => x.UnkFlag2.Value).Subscribe(x => evt.Flags[16] = this.UnkFlag2.Value);
 
     }
 

--- a/src/gui/EditorWindow/TimelinePanel/CommandViewModels/Msg_.cs
+++ b/src/gui/EditorWindow/TimelinePanel/CommandViewModels/Msg_.cs
@@ -159,7 +159,7 @@ public class PagePreview : ReactiveObject
     {
         string text = config.ScriptManager.GetTurnText(turnIndex, pageIndex);
         (string Source, uint CueId)? voiceTuple = config.ScriptManager.GetTurnVoice(turnIndex, pageIndex);
-        this.Dialogue = new StringEntryField($"Page #{pageIndex+1}", this.Editable, text);
+        this.Dialogue = new StringEntryField($"Page #{pageIndex+1}", this.Editable, text, null);
         if (voiceTuple is null)
         {
             this.Source       = null;
@@ -228,7 +228,7 @@ public class OptionPreview : ReactiveObject
     public void Update(DataManager config, int turnIndex, int pageIndex)
     {
         string text = config.ScriptManager.GetTurnText(turnIndex, pageIndex);
-        this.Dialogue = new StringEntryField($"Option #{pageIndex+1}", this.Editable, text);
+        this.Dialogue = new StringEntryField($"Option #{pageIndex+1}", this.Editable, text, null);
     }
 
     public StringEntryField     Dialogue    { get; set; }

--- a/src/gui/EditorWindow/TimelinePanel/TimelinePanel.axaml
+++ b/src/gui/EditorWindow/TimelinePanel/TimelinePanel.axaml
@@ -182,6 +182,7 @@
         <TextBox
           AcceptsReturn="true"
           Text="{Binding Text}"
+          MaxLength="{Binding MaxLength}"
           IsEnabled="{Binding Editable}"/>
       </StackPanel>
     </DataTemplate>

--- a/src/gui/Utilities/FieldViewModels.cs
+++ b/src/gui/Utilities/FieldViewModels.cs
@@ -71,9 +71,10 @@ public class NumEntryField : FieldBase
 // TODO: enable inline non-string elements...?
 public class StringEntryField : FieldBase
 {
-    public StringEntryField(string name, bool editable, string text) : base(name, editable)
+    public StringEntryField(string name, bool editable, string text, int? maxLength) : base(name, editable)
     {
-        _text = text;
+        _text     = text;
+        MaxLength = maxLength;
     }
 
     private string _text;
@@ -82,6 +83,9 @@ public class StringEntryField : FieldBase
         get => _text;
         set => this.RaiseAndSetIfChanged(ref _text, value);
     }
+
+    // i THINK this should be readonly, but subject to change
+    public int? MaxLength { get; }
 }
 
 // ints/floats with definite ranges

--- a/src/lib/FileIO/Formats/EVT/EVT.cs
+++ b/src/lib/FileIO/Formats/EVT/EVT.cs
@@ -172,13 +172,11 @@ public class EVT : ISerializable
                 { ["dataSize"] = this.Commands[i].DataSize });
         }
 
-        //if (this.PointerToEventBmdPath != 0)
         if (this.Flags[12])
         {
             if (rw.IsParselike())
             {
                 this.PointerToEventBmdPath = (int)rw.RelativeTell();
-                //this.EventBmdPathLength = this.EventBmdPath.Length;
                 this.EventBmdPathLength = 48;
                 this.EventBmdPath = this.EventBmdPath.PadRight(48, '\0').Substring(0, 48);
             }
@@ -191,13 +189,11 @@ public class EVT : ISerializable
             this.EventBmdPathLength = 0;
         }
 
-        //if (this.PointerToEventBfPath != 0)
         if (this.Flags[14])
         {
             if (rw.IsParselike())
             {
                 this.PointerToEventBfPath = (int)rw.RelativeTell();
-                //this.EventBfPathLength = this.EventBmdPath.Length;
                 this.EventBfPathLength = 48;
                 this.EventBfPath = this.EventBfPath.PadRight(48, '\0').Substring(0, 48);
             }

--- a/src/lib/FileIO/Formats/EVT/EVT.cs
+++ b/src/lib/FileIO/Formats/EVT/EVT.cs
@@ -116,13 +116,19 @@ public class EVT : ISerializable
 
         rw.RwInt32(ref this.PointerToEventBmdPath);
         rw.RwInt32(ref this.EventBmdPathLength);
+        Trace.Assert(this.EventBmdPathLength == 0 || this.EventBmdPathLength == 48);
         rw.RwInt32(ref this.EmbedMsgFileOfs);
+        Trace.Assert(this.EmbedMsgFileOfs == 0);
         rw.RwInt32(ref this.EmbedMsgFileSize);
+        Trace.Assert(this.EmbedMsgFileSize == 0);
 
         rw.RwInt32(ref this.PointerToEventBfPath);
         rw.RwInt32(ref this.EventBfPathLength);
+        Trace.Assert(this.EventBfPathLength == 0 || this.EventBfPathLength == 48);
         rw.RwInt32(ref this.EmbedBfFileOfs);
+        Trace.Assert(this.EmbedBfFileOfs == 0);
         rw.RwInt32(ref this.EmbedBfFileSize);
+        Trace.Assert(this.EmbedBfFileSize == 0);
 
         this.MarkerFrameCount = (this.FileHeaderSize - (int)rw.RelativeTell()) / 4;
         if (rw.IsConstructlike())
@@ -166,18 +172,42 @@ public class EVT : ISerializable
                 { ["dataSize"] = this.Commands[i].DataSize });
         }
 
-        if (this.PointerToEventBmdPath != 0) {
+        //if (this.PointerToEventBmdPath != 0)
+        if (this.Flags[12])
+        {
             if (rw.IsParselike())
+            {
                 this.PointerToEventBmdPath = (int)rw.RelativeTell();
+                //this.EventBmdPathLength = this.EventBmdPath.Length;
+                this.EventBmdPathLength = 48;
+                this.EventBmdPath = this.EventBmdPath.PadRight(48, '\0').Substring(0, 48);
+            }
             Trace.Assert(this.PointerToEventBmdPath == rw.RelativeTell());
             rw.RwString(ref this.EventBmdPath, this.EventBmdPathLength, Encoding.ASCII);
         }
+        else
+        {
+            this.PointerToEventBmdPath = 0;
+            this.EventBmdPathLength = 0;
+        }
 
-        if (this.PointerToEventBfPath != 0) {
+        //if (this.PointerToEventBfPath != 0)
+        if (this.Flags[14])
+        {
             if (rw.IsParselike())
+            {
                 this.PointerToEventBfPath = (int)rw.RelativeTell();
+                //this.EventBfPathLength = this.EventBmdPath.Length;
+                this.EventBfPathLength = 48;
+                this.EventBfPath = this.EventBfPath.PadRight(48, '\0').Substring(0, 48);
+            }
             Trace.Assert(this.PointerToEventBfPath == rw.RelativeTell());
             rw.RwString(ref this.EventBfPath, this.EventBfPathLength, Encoding.ASCII);
+        }
+        else
+        {
+            this.PointerToEventBfPath = 0;
+            this.EventBfPathLength = 0;
         }
 
         if (rw.IsParselike())


### PR DESCRIPTION
Fixed some issues with the Basics tab, mainly...
- Added editability to fields that wouldn't save before
- Corrected the "embed BF/BMD" verbiage
- ...and the ability of the EVT serializer to write changes to the related strings
- Improved layout and UI generally in terms of spacing and reactively hiding fields

### For a future PR:
- Actually use the custom BF/BMD paths for picking up scripts