### PR TITLE
Implement all camera-related commands

### DIFF
--- a/src/gui/EditorWindow/TimelinePanel/CommandViewModels/CAA_.cs
+++ b/src/gui/EditorWindow/TimelinePanel/CommandViewModels/CAA_.cs
@@ -1,0 +1,40 @@
+namespace EVTUI.ViewModels.TimelineCommands;
+
+public class CAA_ : Generic
+{
+    public CAA_(DataManager config, SerialCommand command, object commandData) : base(config, command, commandData)
+    {
+        this.LongName = "Camera: Additive Animation";
+
+        // animation source
+        // this is technically 0-999, and also camera assets only, so... TODO either way
+        this.AssetID = new IntSelectionField("Asset ID", this.Editable, this.CommandData.AssetId, config.EventManager.AssetIDs);
+        this.AnimationID = new NumEntryField("Animation ID", this.Editable, this.CommandData.AnimationId, 0, 59, 1);
+        this.PlaybackSpeed = new NumEntryField("Playback Speed", this.Editable, this.CommandData.PlaybackSpeed, 0, 10, 0.1);
+
+        // bits
+        this.LoopBool = new BoolChoiceField("Loop Playback?", this.Editable, this.CommandData.Flags[0]);
+        this.EnableViewAngleUpdate = new BoolChoiceField("Enable View Angle Update?", this.Editable, this.CommandData.Flags[2]);
+    }
+
+    // animation source
+    public IntSelectionField AssetID       { get; set; }
+    public NumEntryField     AnimationID   { get; set; }
+    public NumEntryField     PlaybackSpeed { get; set; }
+
+    // bits
+    public BoolChoiceField LoopBool              { get; set; }
+    public BoolChoiceField EnableViewAngleUpdate { get; set; }
+
+    public new void SaveChanges()
+    {
+        base.SaveChanges();
+
+        this.CommandData.AssetId       = this.AssetID.Choice;
+        this.CommandData.AnimationId   = (uint)this.AnimationID.Value;
+        this.CommandData.PlaybackSpeed = (float)this.PlaybackSpeed.Value;
+
+        this.CommandData.Flags[0] = this.LoopBool.Value;
+        this.CommandData.Flags[2] = this.EnableViewAngleUpdate.Value;
+    }
+}

--- a/src/gui/EditorWindow/TimelinePanel/CommandViewModels/CAR_.cs
+++ b/src/gui/EditorWindow/TimelinePanel/CommandViewModels/CAR_.cs
@@ -1,0 +1,23 @@
+namespace EVTUI.ViewModels.TimelineCommands;
+
+public class CAR_ : Generic
+{
+    public CAR_(DataManager config, SerialCommand command, object commandData) : base(config, command, commandData)
+    {
+        this.LongName = "Camera: Reset Animation";
+
+        this.ResetCommand = new BoolChoiceField("Reset Command?", this.Editable, this.CommandData.Flags[0]);
+        this.ResetParameters = new BoolChoiceField("Reset Parameters?", this.Editable, this.CommandData.Flags[1]);
+    }
+
+    public BoolChoiceField ResetCommand    { get; set; }
+    public BoolChoiceField ResetParameters { get; set; }
+
+    public new void SaveChanges()
+    {
+        base.SaveChanges();
+
+        this.CommandData.Flags[0] = this.ResetCommand.Value;
+        this.CommandData.Flags[1] = this.ResetParameters.Value;
+    }
+}

--- a/src/gui/EditorWindow/TimelinePanel/CommandViewModels/CClp.cs
+++ b/src/gui/EditorWindow/TimelinePanel/CommandViewModels/CClp.cs
@@ -1,0 +1,23 @@
+namespace EVTUI.ViewModels.TimelineCommands;
+
+public class CClp : Generic
+{
+    public CClp(DataManager config, SerialCommand command, object commandData) : base(config, command, commandData)
+    {
+        this.LongName = "Camera: Clipping Distance";
+
+        this.NearClip = new NumRangeField("Near Clip", this.Editable, this.CommandData.NearClip, 1, 1000, 1);
+        this.FarClip = new NumRangeField("Far Clip", this.Editable, this.CommandData.FarClip, 1, 999999, 1);
+    }
+
+    public NumRangeField NearClip { get; set; }
+    public NumRangeField FarClip  { get; set; }
+
+    public new void SaveChanges()
+    {
+        base.SaveChanges();
+
+        this.CommandData.NearClip = (float)this.NearClip.Value;
+        this.CommandData.FarClip  = (float)this.FarClip.Value;
+    }
+}

--- a/src/gui/EditorWindow/TimelinePanel/CommandViewModels/CMC_.cs
+++ b/src/gui/EditorWindow/TimelinePanel/CommandViewModels/CMC_.cs
@@ -1,0 +1,137 @@
+using System.Collections.Generic;
+
+using static EVTUI.ViewModels.FieldUtils;
+
+namespace EVTUI.ViewModels.TimelineCommands;
+
+public class CMC_ : Generic
+{
+    public CMC_(DataManager config, SerialCommand command, object commandData) : base(config, command, commandData)
+    {
+        this.LongName = "Camera: Character-Centric Movement";
+
+        // asset/angle/whatever
+        // this is technically 0-999, and also model assets only, so... TODO either way
+        this.AssetID = new IntSelectionField("Model Asset ID", this.Editable, this.CommandData.AssetId, config.EventManager. AssetIDs);
+        this.ShotType = new StringSelectionField("Shot Type", this.Editable, this.ShotTypes.Backward[this.CommandData.ShotType], this.ShotTypes.Keys);
+        this.AngleType = new StringSelectionField("Angle Type", this.Editable, this.AngleTypes.Backward[this.CommandData.AngleType], this.AngleTypes.Keys);
+        this.StartCorrectionFrame = new NumRangeField("Start Correction At Frame", this.Editable, this.CommandData.StartCorrectionFrameNumber, 0, 60, 1);
+
+        // interpolation
+        this.InterpolationSettings = new InterpolationParameters(this.CommandData.InterpolationParameters, this.Editable);
+
+        // focus/blur
+        this.EnableDOF = new BoolChoiceField("Enable Depth-Of-Field?", this.Editable, this.CommandData.Flags[0]);
+        this.EnableCustomDOF = new BoolChoiceField("Customize Depth-Of-Field?", this.Editable, this.CommandData.Flags[1]);
+        this.FocalDistance = new NumRangeField("Focal Distance", this.Editable, this.CommandData.FocalPlaneDistance, 0, 999999, 1);
+        this.NearBlurDistance = new NumRangeField("Near Blur Distance", this.Editable, this.CommandData.NearBlurSurface, 0, 999999, 1);
+        this.FarBlurDistance = new NumRangeField("Far Blur Distance", this.Editable, this.CommandData.FarBlurSurface, 0, 999999, 1);
+        this.BlurStrength = new NumRangeField("Blur Strength", this.Editable, this.CommandData.BlurStrength, 0, 1, 0.1);
+        this.BlurType = new StringSelectionField("Blur Type", this.Editable, this.BlurTypes.Backward[this.CommandData.BlurType], this.BlurTypes.Keys);
+
+        // message
+        this.EnableMessageCoordinates = new BoolChoiceField("Directly Specify Message Coordinates?", this.Editable, this.CommandData.Flags[5]);
+        this.MessageCoordinateType = new StringSelectionField("Coordinate Type", this.Editable, this.MessageCoordinateTypes.Backward[this.CommandData.MessageCoordinateType], this.MessageCoordinateTypes.Keys);
+        this.MessageX = new NumRangeField("X Coordinate", this.Editable, this.CommandData.MessageCoordinates[0], -9999, 9999, 1);
+        this.MessageY = new NumRangeField("Y Coordinate", this.Editable, this.CommandData.MessageCoordinates[1], -9999, 9999, 1);
+    }
+
+    // asset/angle/whatever
+    public IntSelectionField    AssetID              { get; set; }
+    public StringSelectionField ShotType             { get; set; }
+    public StringSelectionField AngleType            { get; set; }
+    public NumRangeField        StartCorrectionFrame { get; set; }
+
+    // interpolation
+    public InterpolationParameters InterpolationSettings { get; set; }
+
+    // focus/blur
+    public BoolChoiceField      EnableDOF        { get; set; }
+    public BoolChoiceField      EnableCustomDOF  { get; set; }
+    public NumRangeField        FocalDistance    { get; set; }
+    public NumRangeField        NearBlurDistance { get; set; }
+    public NumRangeField        FarBlurDistance  { get; set; }
+    public NumRangeField        BlurStrength     { get; set; }
+    public StringSelectionField BlurType         { get; set; }
+
+    // message
+    public BoolChoiceField      EnableMessageCoordinates { get; set; }
+    public StringSelectionField MessageCoordinateType    { get; set; }
+    public NumRangeField        MessageX                 { get; set; }
+    public NumRangeField        MessageY                 { get; set; }
+
+    public new void SaveChanges()
+    {
+        base.SaveChanges();
+
+        this.CommandData.Flags[0] = this.EnableDOF.Value;
+        this.CommandData.Flags[1] = this.EnableCustomDOF.Value;
+        this.CommandData.Flags[5] = this.EnableMessageCoordinates.Value;
+
+        this.CommandData.StartCorrectionFrameNumber = (ushort)this.StartCorrectionFrame.Value;
+        this.CommandData.InterpolationParameters = this.InterpolationSettings.Compose();
+
+        this.CommandData.AssetId = this.AssetID.Choice;
+        this.CommandData.ShotType = this.ShotTypes.Forward[this.ShotType.Choice];
+        this.CommandData.AngleType = this.AngleTypes.Forward[this.AngleType.Choice];
+
+        this.CommandData.FocalPlaneDistance = (float)this.FocalDistance.Value;
+        this.CommandData.NearBlurSurface = (float)this.NearBlurDistance.Value;
+        this.CommandData.FarBlurSurface = (float)this.FarBlurDistance.Value;
+        this.CommandData.BlurStrength = (float)this.BlurStrength.Value;
+
+        this.CommandData.BlurType = this.BlurTypes.Forward[this.BlurType.Choice];
+        this.CommandData.MessageCoordinateType = this.MessageCoordinateTypes.Forward[this.MessageCoordinateType.Choice];
+        this.CommandData.MessageCoordinates[0] = (float)this.MessageX.Value;
+        this.CommandData.MessageCoordinates[1] = (float)this.MessageY.Value;
+    }
+
+    public BiDict<string, uint> ShotTypes = new BiDict<string, uint>
+    (
+        new Dictionary<string, uint>
+        {
+            {"Close-Up (Face)",       0},
+            {"Bust-Up",               1},
+            {"Whole Body",            2},
+            {"Overhead / Bird's Eye", 3},
+        }
+    );
+
+    public BiDict<string, uint> AngleTypes = new BiDict<string, uint>
+    (
+        new Dictionary<string, uint>
+        {
+            {"Front Right Cheek", 0},
+            {"Front Direct",      1},
+            {"Front Left Cheek",  2},
+            {"Back Right Cheek",  3},
+            {"Back Direct",       4},
+            {"Back Left Cheek",   5},
+        }
+    );
+
+    public BiDict<string, uint> BlurTypes = new BiDict<string, uint>
+    (
+        new Dictionary<string, uint>
+        {
+            {"5x5 Gaussian Filter",  0},
+            {"2-Iteration Gaussian", 1},
+            {"3-Iteration Gaussian", 2},
+            {"5-Iteration Gaussian", 3},
+            {"7-Iteration Gaussian", 4},
+        }
+    );
+
+    public BiDict<string, uint> MessageCoordinateTypes = new BiDict<string, uint>
+    (
+        new Dictionary<string, uint>
+        {
+            {"Top Left",      0},
+            {"Top Center",    1},
+            {"Top Right",     2},
+            {"Bottom Left",   3},
+            {"Bottom Center", 4},
+            {"Bottom Right",  5},
+        }
+    );
+}

--- a/src/gui/EditorWindow/TimelinePanel/CommandViewModels/CMCn.cs
+++ b/src/gui/EditorWindow/TimelinePanel/CommandViewModels/CMCn.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+
+using static EVTUI.ViewModels.FieldUtils;
+
+namespace EVTUI.ViewModels.TimelineCommands;
+
+public class CMCn : Generic
+{
+    public CMCn(DataManager config, SerialCommand command, object commandData) : base(config, command, commandData)
+    {
+        this.LongName = "Camera: Continuous Movement";
+
+        this.DirectionType = new StringSelectionField("Direction Type", this.Editable, this.DirectionTypes.Backward[this.CommandData.DirectionType], this.DirectionTypes.Keys);
+        this.Distance = new NumRangeField("Distance", this.Editable, this.CommandData.Distance, 0, 0.1, 0.001);
+    }
+
+    public StringSelectionField DirectionType { get; set; }
+    public NumRangeField        Distance      { get; set; }
+
+    public new void SaveChanges()
+    {
+        base.SaveChanges();
+
+        this.CommandData.DirectionType = this.DirectionTypes.Forward[this.DirectionType.Choice];
+        this.CommandData.Distance = (float)this.Distance.Value;
+    }
+
+    public BiDict<string, uint> DirectionTypes = new BiDict<string, uint>
+    (
+        new Dictionary<string, uint>
+        {
+            {"None",    0},
+            {"Forward", 1},
+            {"Back",    2},
+            {"Left",    3},
+            {"Right",   4},
+            {"Up",      5},
+            {"Down",    6},
+        }
+    );
+}

--- a/src/gui/EditorWindow/TimelinePanel/CommandViewModels/CMD_.cs
+++ b/src/gui/EditorWindow/TimelinePanel/CommandViewModels/CMD_.cs
@@ -1,0 +1,98 @@
+using System.Collections.Generic;
+
+using static EVTUI.ViewModels.FieldUtils;
+
+namespace EVTUI.ViewModels.TimelineCommands;
+
+public class CMD_ : Generic
+{
+    public CMD_(DataManager config, SerialCommand command, object commandData) : base(config, command, commandData)
+    {
+        this.LongName = "Camera: Coordinate Movement";
+
+        this.AngleOfView = new NumRangeField("Angle of View", this.Editable, this.CommandData.AngleOfView, 1, 180, 1);
+
+        // viewport target position
+        this.ViewportX = new NumRangeField("X", this.Editable, this.CommandData.ViewportCoordinates[0], -99999, 99999, 1);
+        this.ViewportY = new NumRangeField("Y", this.Editable, this.CommandData.ViewportCoordinates[1], -99999, 99999, 1);
+        this.ViewportZ = new NumRangeField("Z", this.Editable, this.CommandData.ViewportCoordinates[2], -99999, 99999, 1);
+
+        // viewport target rotation
+        // i may have yaw and pitch switched around here, dunno
+        this.ViewportYaw = new NumRangeField("Yaw", this.Editable, this.CommandData.ViewportRotation[0], -180, 180, 1);
+        this.ViewportPitch = new NumRangeField("Pitch", this.Editable, this.CommandData.ViewportRotation[1], -180, 180, 1);
+        this.ViewportRoll = new NumRangeField("Roll", this.Editable, this.CommandData.ViewportRotation[2], -180, 180, 1);
+
+        // interpolation
+        this.InterpolationSettings = new InterpolationParameters(this.CommandData.InterpolationParameters, this.Editable);
+
+        // focus/blur
+        this.EnableDOF = new BoolChoiceField("Enable Depth-Of-Field?", this.Editable, this.CommandData.Flags[4]);
+        this.FocalDistance = new NumRangeField("Focal Distance", this.Editable, this.CommandData.FocalPlaneDistance, 0, 999999, 1);
+        this.NearBlurDistance = new NumRangeField("Near Blur Distance", this.Editable, this.CommandData.NearBlurSurface, 0, 999999, 1);
+        this.FarBlurDistance = new NumRangeField("Far Blur Distance", this.Editable, this.CommandData.FarBlurSurface, 0, 999999, 1);
+        this.BlurStrength = new NumRangeField("Blur Strength", this.Editable, this.CommandData.BlurStrength, 0, 1, 0.1);
+        this.BlurType = new StringSelectionField("Blur Type", this.Editable, this.BlurTypes.Backward[this.CommandData.BlurType], this.BlurTypes.Keys);
+
+    }
+
+    public NumRangeField AngleOfView { get; set; }
+
+    // viewport target position
+    public NumRangeField ViewportX { get; set; }
+    public NumRangeField ViewportY { get; set; }
+    public NumRangeField ViewportZ { get; set; }
+
+    // viewport target rotation
+    public NumRangeField ViewportYaw   { get; set; }
+    public NumRangeField ViewportPitch { get; set; }
+    public NumRangeField ViewportRoll  { get; set; }
+
+    // interpolation
+    public InterpolationParameters InterpolationSettings { get; set; }
+
+    // focus/blur
+    public BoolChoiceField      EnableDOF        { get; set; }
+    public NumRangeField        FocalDistance    { get; set; }
+    public NumRangeField        NearBlurDistance { get; set; }
+    public NumRangeField        FarBlurDistance  { get; set; }
+    public NumRangeField        BlurStrength     { get; set; }
+    public StringSelectionField BlurType         { get; set; }
+
+    public new void SaveChanges()
+    {
+        base.SaveChanges();
+
+        this.CommandData.Flags[4] = this.EnableDOF.Value;
+
+        this.CommandData.ViewportCoordinates[0] = (float)this.ViewportX.Value;
+        this.CommandData.ViewportCoordinates[1] = (float)this.ViewportY.Value;
+        this.CommandData.ViewportCoordinates[2] = (float)this.ViewportZ.Value;
+
+        this.CommandData.ViewportRotation[0] = (float)this.ViewportYaw.Value;
+        this.CommandData.ViewportRotation[1] = (float)this.ViewportPitch.Value;
+        this.CommandData.ViewportRotation[2] = (float)this.ViewportRoll.Value;
+
+        this.CommandData.AngleOfView = (float)this.AngleOfView.Value;
+        this.CommandData.InterpolationParameters = this.InterpolationSettings.Compose();
+
+        this.CommandData.FocalPlaneDistance = (float)this.FocalDistance.Value;
+        this.CommandData.NearBlurSurface = (float)this.NearBlurDistance.Value;
+        this.CommandData.FarBlurSurface = (float)this.FarBlurDistance.Value;
+
+        this.CommandData.BlurStrength = (float)this.BlurStrength.Value;
+        this.CommandData.BlurType = this.BlurTypes.Forward[this.BlurType.Choice];
+    }
+
+    public BiDict<string, uint> BlurTypes = new BiDict<string, uint>
+    (
+        new Dictionary<string, uint>
+        {
+            {"5x5 Gaussian Filter",  0},
+            {"2-Iteration Gaussian", 1},
+            {"3-Iteration Gaussian", 2},
+            {"5-Iteration Gaussian", 3},
+            {"7-Iteration Gaussian", 4},
+        }
+    );
+}

--- a/src/gui/EditorWindow/TimelinePanel/CommandViewModels/CQuk.cs
+++ b/src/gui/EditorWindow/TimelinePanel/CommandViewModels/CQuk.cs
@@ -1,0 +1,29 @@
+namespace EVTUI.ViewModels.TimelineCommands;
+
+public class CQuk : Generic
+{
+    public CQuk(DataManager config, SerialCommand command, object commandData) : base(config, command, commandData)
+    {
+        this.LongName = "Camera: Quake Effect";
+
+        this.StrengthOfShaking = new NumRangeField("Strength of Shaking", this.Editable, this.CommandData.StrengthOfShaking, 0, 100, 1);
+        this.DegreeOfPitch = new NumRangeField("Degree of Pitch", this.Editable, this.CommandData.DegreeOfPitch, 0, 1, 0.01);
+        this.FadeInFrames = new NumRangeField("Fade-In Frames", this.Editable, this.CommandData.FadeInFrames, 0, 10000, 1);
+        this.FadeOutFrames = new NumRangeField("Fade-Out Frames", this.Editable, this.CommandData.FadeOutFrames, 0, 10000, 1);
+    }
+
+    public NumRangeField StrengthOfShaking { get; set; }
+    public NumRangeField DegreeOfPitch     { get; set; }
+    public NumRangeField FadeInFrames      { get; set; }
+    public NumRangeField FadeOutFrames     { get; set; }
+
+    public new void SaveChanges()
+    {
+        base.SaveChanges();
+
+        this.CommandData.StrengthOfShaking = (float)this.StrengthOfShaking.Value;
+        this.CommandData.DegreeOfPitch     = (float)this.DegreeOfPitch.Value;
+        this.CommandData.FadeInFrames      = (uint)this.FadeInFrames.Value;
+        this.CommandData.FadeOutFrames     = (uint)this.FadeOutFrames.Value;
+    }
+}

--- a/src/gui/EditorWindow/TimelinePanel/CommandViewModels/CSA_.cs
+++ b/src/gui/EditorWindow/TimelinePanel/CommandViewModels/CSA_.cs
@@ -1,0 +1,152 @@
+using System.Collections.Generic;
+
+using static EVTUI.ViewModels.FieldUtils;
+
+namespace EVTUI.ViewModels.TimelineCommands;
+
+public class CSA_ : Generic
+{
+    public CSA_(DataManager config, SerialCommand command, object commandData) : base(config, command, commandData)
+    {
+        this.LongName = "Camera: Base Animation";
+
+        // animation source
+        // this is technically 0-999, and also camera assets only, so... TODO either way
+        this.AssetID = new IntSelectionField("Asset ID", this.Editable, this.CommandData.AssetId, config.EventManager.AssetIDs);
+        this.AnimationID = new NumEntryField("Animation ID", this.Editable, this.CommandData.AnimationId, 0, 59, 1);
+        this.PlaybackSpeed = new NumEntryField("Playback Speed", this.Editable, this.CommandData.PlaybackSpeed, 0, 10, 0.1);
+        this.StartingFrame = new NumEntryField("Starting Frame", this.Editable, this.CommandData.StartingFrame, 0, 99999, 1);
+        this.LoopBool = new BoolChoiceField("Loop Playback?", this.Editable, this.CommandData.Flags[0]);
+        this.EnableCorrectionParameters = new BoolChoiceField("Enable Viewport Updates?", this.Editable, this.CommandData.Flags[1]);
+
+        // viewport target position
+        this.ViewportX = new NumRangeField("X", this.Editable, this.CommandData.ViewportCoordinates[0], -99999, 99999, 1);
+        this.ViewportY = new NumRangeField("Y", this.Editable, this.CommandData.ViewportCoordinates[1], -99999, 99999, 1);
+        this.ViewportZ = new NumRangeField("Z", this.Editable, this.CommandData.ViewportCoordinates[2], -99999, 99999, 1);
+
+        // viewport target rotation
+        // i may have yaw and pitch switched around here, dunno
+        this.ViewportYaw = new NumRangeField("Yaw", this.Editable, this.CommandData.ViewportRotation[0], -180, 180, 1);
+        this.ViewportPitch = new NumRangeField("Pitch", this.Editable, this.CommandData.ViewportRotation[1], -180, 180, 1);
+        this.ViewportRoll = new NumRangeField("Roll", this.Editable, this.CommandData.ViewportRotation[2], -180, 180, 1);
+
+        // focus/blur
+        this.EnableDOF = new BoolChoiceField("Enable Depth-Of-Field?", this.Editable, this.CommandData.Flags[2]);
+        this.FocalDistance = new NumRangeField("Focal Distance", this.Editable, this.CommandData.FocalPlaneDistance, 0, 999999, 1);
+        this.NearBlurDistance = new NumRangeField("Near Blur Distance", this.Editable, this.CommandData.NearBlurSurface, 0, 999999, 1);
+        this.FarBlurDistance = new NumRangeField("Far Blur Distance", this.Editable, this.CommandData.FarBlurSurface, 0, 999999, 1);
+        this.BlurStrength = new NumRangeField("Blur Strength", this.Editable, this.CommandData.BlurStrength, 0, 1, 0.1);
+        this.BlurType = new StringSelectionField("Blur Type", this.Editable, this.BlurTypes.Backward[this.CommandData.BlurType], this.BlurTypes.Keys);
+
+        // message
+        this.EnableMessageCoordinates = new BoolChoiceField("Directly Specify Message Coordinates?", this.Editable, this.CommandData.Flags[5]);
+        this.MessageCoordinateType = new StringSelectionField("Coordinate Type", this.Editable, this.MessageCoordinateTypes.Backward[this.CommandData.MessageCoordinateType], this.MessageCoordinateTypes.Keys);
+        this.MessageX = new NumRangeField("X Coordinate", this.Editable, this.CommandData.MessageCoordinates[0], -9999, 9999, 1);
+        this.MessageY = new NumRangeField("Y Coordinate", this.Editable, this.CommandData.MessageCoordinates[1], -9999, 9999, 1);
+
+        // unknown
+        this.UnkBool = new BoolChoiceField("Unknown #1", this.Editable, this.CommandData.Flags[8]);
+        this.UnkEnum = new NumEntryField("Unknown #2", this.Editable, this.CommandData.UnkEnum, 0, 2, 1);
+        this.UnkInd = new NumEntryField("Unknown #3", this.Editable, this.CommandData.UnkInd, 0, 31, 1);
+    }
+
+    // animation source
+    public IntSelectionField AssetID                    { get; set; }
+    public NumEntryField     AnimationID                { get; set; }
+    public NumEntryField     PlaybackSpeed              { get; set; }
+    public NumEntryField     StartingFrame              { get; set; }
+    public BoolChoiceField   LoopBool                   { get; set; }
+    public BoolChoiceField   EnableCorrectionParameters { get; set; }
+
+    // viewport target position
+    public NumRangeField ViewportX { get; set; }
+    public NumRangeField ViewportY { get; set; }
+    public NumRangeField ViewportZ { get; set; }
+
+    // viewport target rotation
+    public NumRangeField ViewportYaw   { get; set; }
+    public NumRangeField ViewportPitch { get; set; }
+    public NumRangeField ViewportRoll  { get; set; }
+
+    // focus/blur
+    public BoolChoiceField      EnableDOF        { get; set; }
+    public NumRangeField        FocalDistance    { get; set; }
+    public NumRangeField        NearBlurDistance { get; set; }
+    public NumRangeField        FarBlurDistance  { get; set; }
+    public NumRangeField        BlurStrength     { get; set; }
+    public StringSelectionField BlurType         { get; set; }
+
+    // message
+    public BoolChoiceField      EnableMessageCoordinates { get; set; }
+    public StringSelectionField MessageCoordinateType    { get; set; }
+    public NumRangeField        MessageX                 { get; set; }
+    public NumRangeField        MessageY                 { get; set; }
+
+    // unknown
+    public BoolChoiceField UnkBool { get; set; }
+    public NumEntryField   UnkEnum { get; set; }
+    public NumEntryField   UnkInd  { get; set; }
+
+    public new void SaveChanges()
+    {
+        base.SaveChanges();
+
+        this.CommandData.Flags[0] = this.LoopBool.Value;
+        this.CommandData.Flags[1] = this.EnableCorrectionParameters.Value;
+        this.CommandData.Flags[2] = this.EnableDOF.Value;
+        this.CommandData.Flags[5] = this.EnableMessageCoordinates.Value;
+        this.CommandData.Flags[8] = this.UnkBool.Value;
+
+        this.CommandData.AssetId       = this.AssetID.Choice;
+        this.CommandData.AnimationId   = (uint)this.AnimationID.Value;
+        this.CommandData.PlaybackSpeed = (float)this.PlaybackSpeed.Value;
+        this.CommandData.StartingFrame = (uint)this.StartingFrame.Value;
+
+        this.CommandData.ViewportCoordinates[0] = (float)this.ViewportX.Value;
+        this.CommandData.ViewportCoordinates[1] = (float)this.ViewportY.Value;
+        this.CommandData.ViewportCoordinates[2] = (float)this.ViewportZ.Value;
+
+        this.CommandData.ViewportRotation[0] = (float)this.ViewportYaw.Value;
+        this.CommandData.ViewportRotation[1] = (float)this.ViewportPitch.Value;
+        this.CommandData.ViewportRotation[2] = (float)this.ViewportRoll.Value;
+
+        this.CommandData.FocalPlaneDistance = (float)this.FocalDistance.Value;
+        this.CommandData.NearBlurSurface = (float)this.NearBlurDistance.Value;
+        this.CommandData.FarBlurSurface = (float)this.FarBlurDistance.Value;
+
+        this.CommandData.BlurStrength = (float)this.BlurStrength.Value;
+        this.CommandData.BlurType = this.BlurTypes.Forward[this.BlurType.Choice];
+
+        this.CommandData.MessageCoordinateType = this.MessageCoordinateTypes.Forward[this.MessageCoordinateType.Choice];
+        this.CommandData.MessageCoordinates[0] = (float)this.MessageX.Value;
+        this.CommandData.MessageCoordinates[1] = (float)this.MessageY.Value;
+
+        this.CommandData.UnkEnum = (byte)this.UnkEnum.Value;
+        this.CommandData.UnkInd  = (byte)this.UnkInd.Value;
+    }
+
+    public BiDict<string, uint> BlurTypes = new BiDict<string, uint>
+    (
+        new Dictionary<string, uint>
+        {
+            {"5x5 Gaussian Filter",  0},
+            {"2-Iteration Gaussian", 1},
+            {"3-Iteration Gaussian", 2},
+            {"5-Iteration Gaussian", 3},
+            {"7-Iteration Gaussian", 4},
+        }
+    );
+
+    public BiDict<string, uint> MessageCoordinateTypes = new BiDict<string, uint>
+    (
+        new Dictionary<string, uint>
+        {
+            {"Top Left",      0},
+            {"Top Center",    1},
+            {"Top Right",     2},
+            {"Bottom Left",   3},
+            {"Bottom Center", 4},
+            {"Bottom Right",  5},
+        }
+    );
+}

--- a/src/gui/EditorWindow/TimelinePanel/CommandViewModels/CSDD.cs
+++ b/src/gui/EditorWindow/TimelinePanel/CommandViewModels/CSDD.cs
@@ -1,0 +1,77 @@
+namespace EVTUI.ViewModels.TimelineCommands;
+
+public class CSDD : Generic
+{
+    public CSDD(DataManager config, SerialCommand command, object commandData) : base(config, command, commandData)
+    {
+        this.LongName = "Camera: Placement (Old)";
+
+        this.AngleOfView = new NumRangeField("Angle of View", this.Editable, this.CommandData.AngleOfView, 1, 180, 1);
+
+        // viewport target position
+        this.ViewportX = new NumRangeField("X", this.Editable, this.CommandData.ViewportCoordinates[0], -99999, 99999, 1);
+        this.ViewportY = new NumRangeField("Y", this.Editable, this.CommandData.ViewportCoordinates[1], -99999, 99999, 1);
+        this.ViewportZ = new NumRangeField("Z", this.Editable, this.CommandData.ViewportCoordinates[2], -99999, 99999, 1);
+
+        // viewport target rotation
+        // i may have yaw and pitch switched around here, dunno
+        this.ViewportYaw = new NumRangeField("Yaw", this.Editable, this.CommandData.ViewportRotation[0], -180, 180, 1);
+        this.ViewportPitch = new NumRangeField("Pitch", this.Editable, this.CommandData.ViewportRotation[1], -180, 180, 1);
+        this.ViewportRoll = new NumRangeField("Roll", this.Editable, this.CommandData.ViewportRotation[2], -180, 180, 1);
+
+        // focus/blur
+        this.EnableDOF = new BoolChoiceField("Enable Depth-Of-Field?", this.Editable, this.CommandData.Flags[0]);
+        this.FocalDistance = new NumRangeField("Focal Distance", this.Editable, this.CommandData.FocalPlaneDistance, 0, 999999, 1);
+        this.NearBlurDistance = new NumRangeField("Near Blur Distance", this.Editable, this.CommandData.NearBlurSurface, 0, 999999, 1);
+        this.FarBlurDistance = new NumRangeField("Far Blur Distance", this.Editable, this.CommandData.FarBlurSurface, 0, 999999, 1);
+        this.BlurStrength = new NumRangeField("Blur Strength", this.Editable, this.CommandData.BlurStrength, 0, 1, 0.1);
+
+        // unknown
+        this.UnkBool = new BoolChoiceField("Unknown #1", this.Editable, this.CommandData.Flags[1]);
+    }
+
+    public NumRangeField AngleOfView { get; set; }
+
+    // viewport target position
+    public NumRangeField ViewportX { get; set; }
+    public NumRangeField ViewportY { get; set; }
+    public NumRangeField ViewportZ { get; set; }
+
+    // viewport target rotation
+    public NumRangeField ViewportYaw   { get; set; }
+    public NumRangeField ViewportPitch { get; set; }
+    public NumRangeField ViewportRoll  { get; set; }
+
+    // focus/blur
+    public BoolChoiceField      EnableDOF        { get; set; }
+    public NumRangeField        FocalDistance    { get; set; }
+    public NumRangeField        NearBlurDistance { get; set; }
+    public NumRangeField        FarBlurDistance  { get; set; }
+    public NumRangeField        BlurStrength     { get; set; }
+
+    // unknown
+    public BoolChoiceField UnkBool   { get; set; }
+
+    public new void SaveChanges()
+    {
+        base.SaveChanges();
+
+        this.CommandData.Flags[0] = this.EnableDOF.Value;
+        this.CommandData.Flags[1] = this.UnkBool.Value;
+
+        this.CommandData.ViewportCoordinates[0] = (float)this.ViewportX.Value;
+        this.CommandData.ViewportCoordinates[1] = (float)this.ViewportY.Value;
+        this.CommandData.ViewportCoordinates[2] = (float)this.ViewportZ.Value;
+
+        this.CommandData.ViewportRotation[0] = (float)this.ViewportYaw.Value;
+        this.CommandData.ViewportRotation[1] = (float)this.ViewportPitch.Value;
+        this.CommandData.ViewportRotation[2] = (float)this.ViewportRoll.Value;
+
+        this.CommandData.AngleOfView = (float)this.AngleOfView.Value;
+
+        this.CommandData.FocalPlaneDistance = (float)this.FocalDistance.Value;
+        this.CommandData.NearBlurSurface = (float)this.NearBlurDistance.Value;
+        this.CommandData.FarBlurSurface = (float)this.FarBlurDistance.Value;
+        this.CommandData.BlurStrength = (float)this.BlurStrength.Value;
+    }
+}

--- a/src/gui/EditorWindow/TimelinePanel/CommandViewModels/CSD_.cs
+++ b/src/gui/EditorWindow/TimelinePanel/CommandViewModels/CSD_.cs
@@ -1,0 +1,149 @@
+using System.Collections.Generic;
+
+using static EVTUI.ViewModels.FieldUtils;
+
+namespace EVTUI.ViewModels.TimelineCommands;
+
+public class CSD_ : Generic
+{
+    public CSD_(DataManager config, SerialCommand command, object commandData) : base(config, command, commandData)
+    {
+        this.LongName = "Camera: Placement";
+
+        this.AngleOfView = new NumRangeField("Angle of View", this.Editable, this.CommandData.AngleOfView, 1, 180, 1);
+
+        // viewport target position
+        this.ViewportX = new NumRangeField("X", this.Editable, this.CommandData.ViewportCoordinates[0], -99999, 99999, 1);
+        this.ViewportY = new NumRangeField("Y", this.Editable, this.CommandData.ViewportCoordinates[1], -99999, 99999, 1);
+        this.ViewportZ = new NumRangeField("Z", this.Editable, this.CommandData.ViewportCoordinates[2], -99999, 99999, 1);
+
+        // viewport target rotation
+        // i may have yaw and pitch switched around here, dunno
+        this.ViewportYaw = new NumRangeField("Yaw", this.Editable, this.CommandData.ViewportRotation[0], -180, 180, 1);
+        this.ViewportPitch = new NumRangeField("Pitch", this.Editable, this.CommandData.ViewportRotation[1], -180, 180, 1);
+        this.ViewportRoll = new NumRangeField("Roll", this.Editable, this.CommandData.ViewportRotation[2], -180, 180, 1);
+
+        // focus/blur
+        this.EnableDOF = new BoolChoiceField("Enable Depth-Of-Field?", this.Editable, this.CommandData.Flags[0]);
+        this.FocalDistance = new NumRangeField("Focal Distance", this.Editable, this.CommandData.FocalPlaneDistance, 0, 999999, 1);
+        this.NearBlurDistance = new NumRangeField("Near Blur Distance", this.Editable, this.CommandData.NearBlurSurface, 0, 999999, 1);
+        this.FarBlurDistance = new NumRangeField("Far Blur Distance", this.Editable, this.CommandData.FarBlurSurface, 0, 999999, 1);
+        this.BlurStrength = new NumRangeField("Blur Strength", this.Editable, this.CommandData.BlurStrength, 0, 1, 0.1);
+        this.BlurType = new StringSelectionField("Blur Type", this.Editable, this.BlurTypes.Backward[this.CommandData.BlurType], this.BlurTypes.Keys);
+
+        // message
+        this.EnableMessageCoordinates = new BoolChoiceField("Directly Specify Message Coordinates?", this.Editable, this.CommandData.Flags[5]);
+        this.MessageCoordinateType = new StringSelectionField("Coordinate Type", this.Editable, this.MessageCoordinateTypes.Backward[this.CommandData.MessageCoordinateType], this.MessageCoordinateTypes.Keys);
+        this.MessageX = new NumRangeField("X Coordinate", this.Editable, this.CommandData.MessageCoordinates[0], -9999, 9999, 1);
+        this.MessageY = new NumRangeField("Y Coordinate", this.Editable, this.CommandData.MessageCoordinates[1], -9999, 9999, 1);
+
+        // unknown
+        this.UnkBool = new BoolChoiceField("Unknown #1", this.Editable, this.CommandData.Flags[8]);
+        this.UnkEnum = new NumEntryField("Unknown #2", this.Editable, this.CommandData.UnkEnum, 0, 2, 1);
+        this.UnkInd = new NumEntryField("Unknown #3", this.Editable, this.CommandData.UnkInd, 0, 31, 1);
+        this.SuperUnk1 = new NumEntryField("Unknown #4", this.Editable, this.CommandData.SuperUnk1, 0, 255, 1);
+        this.SuperUnk2 = new NumEntryField("Unknown #5", this.Editable, this.CommandData.SuperUnk2, 0, 255, 1);
+        this.UnkCoord1 = new NumRangeField("Unknown #6", this.Editable, this.CommandData.UnkCoordinates[0], -99999, 99999, 1);
+        this.UnkCoord2 = new NumRangeField("Unknown #7", this.Editable, this.CommandData.UnkCoordinates[1], -99999, 99999, 1);
+        this.UnkCoord3 = new NumRangeField("Unknown #8", this.Editable, this.CommandData.UnkCoordinates[2], -99999, 99999, 1);
+    }
+
+    public NumRangeField AngleOfView { get; set; }
+
+    // viewport target position
+    public NumRangeField ViewportX { get; set; }
+    public NumRangeField ViewportY { get; set; }
+    public NumRangeField ViewportZ { get; set; }
+
+    // viewport target rotation
+    public NumRangeField ViewportYaw   { get; set; }
+    public NumRangeField ViewportPitch { get; set; }
+    public NumRangeField ViewportRoll  { get; set; }
+
+    // focus/blur
+    public BoolChoiceField      EnableDOF        { get; set; }
+    public NumRangeField        FocalDistance    { get; set; }
+    public NumRangeField        NearBlurDistance { get; set; }
+    public NumRangeField        FarBlurDistance  { get; set; }
+    public NumRangeField        BlurStrength     { get; set; }
+    public StringSelectionField BlurType         { get; set; }
+
+    // message
+    public BoolChoiceField      EnableMessageCoordinates { get; set; }
+    public StringSelectionField MessageCoordinateType    { get; set; }
+    public NumRangeField        MessageX                 { get; set; }
+    public NumRangeField        MessageY                 { get; set; }
+
+    // unknown
+    public BoolChoiceField UnkBool   { get; set; }
+    public NumEntryField   UnkEnum   { get; set; }
+    public NumEntryField   UnkInd    { get; set; }
+    public NumEntryField   SuperUnk1 { get; set; }
+    public NumEntryField   SuperUnk2 { get; set; }
+    public NumRangeField   UnkCoord1 { get; set; }
+    public NumRangeField   UnkCoord2 { get; set; }
+    public NumRangeField   UnkCoord3 { get; set; }
+
+    public new void SaveChanges()
+    {
+        base.SaveChanges();
+
+        this.CommandData.Flags[0] = this.EnableDOF.Value;
+        this.CommandData.Flags[5] = this.EnableMessageCoordinates.Value;
+        this.CommandData.Flags[8] = this.UnkBool.Value;
+
+        this.CommandData.ViewportCoordinates[0] = (float)this.ViewportX.Value;
+        this.CommandData.ViewportCoordinates[1] = (float)this.ViewportY.Value;
+        this.CommandData.ViewportCoordinates[2] = (float)this.ViewportZ.Value;
+
+        this.CommandData.ViewportRotation[0] = (float)this.ViewportYaw.Value;
+        this.CommandData.ViewportRotation[1] = (float)this.ViewportPitch.Value;
+        this.CommandData.ViewportRotation[2] = (float)this.ViewportRoll.Value;
+
+        this.CommandData.AngleOfView = (float)this.AngleOfView.Value;
+
+        this.CommandData.FocalPlaneDistance = (float)this.FocalDistance.Value;
+        this.CommandData.NearBlurSurface = (float)this.NearBlurDistance.Value;
+        this.CommandData.FarBlurSurface = (float)this.FarBlurDistance.Value;
+
+        this.CommandData.BlurStrength = (float)this.BlurStrength.Value;
+        this.CommandData.BlurType = this.BlurTypes.Forward[this.BlurType.Choice];
+
+        this.CommandData.MessageCoordinateType = this.MessageCoordinateTypes.Forward[this.MessageCoordinateType.Choice];
+        this.CommandData.MessageCoordinates[0] = (float)this.MessageX.Value;
+        this.CommandData.MessageCoordinates[1] = (float)this.MessageY.Value;
+
+        this.CommandData.UnkEnum           = (byte)this.UnkEnum.Value;
+        this.CommandData.UnkInd            = (byte)this.UnkInd.Value;
+        this.CommandData.SuperUnk1         = (byte)this.SuperUnk1.Value;
+        this.CommandData.SuperUnk2         = (byte)this.SuperUnk2.Value;
+        this.CommandData.UnkCoordinates[0] = (float)this.UnkCoord1.Value;
+        this.CommandData.UnkCoordinates[1] = (float)this.UnkCoord2.Value;
+        this.CommandData.UnkCoordinates[2] = (float)this.UnkCoord3.Value;
+    }
+
+    public BiDict<string, uint> BlurTypes = new BiDict<string, uint>
+    (
+        new Dictionary<string, uint>
+        {
+            {"5x5 Gaussian Filter",  0},
+            {"2-Iteration Gaussian", 1},
+            {"3-Iteration Gaussian", 2},
+            {"5-Iteration Gaussian", 3},
+            {"7-Iteration Gaussian", 4},
+        }
+    );
+
+    public BiDict<string, uint> MessageCoordinateTypes = new BiDict<string, uint>
+    (
+        new Dictionary<string, uint>
+        {
+            {"Top Left",      0},
+            {"Top Center",    1},
+            {"Top Right",     2},
+            {"Bottom Left",   3},
+            {"Bottom Center", 4},
+            {"Bottom Right",  5},
+        }
+    );
+}

--- a/src/gui/EditorWindow/TimelinePanel/CommandViewModels/CSEc.cs
+++ b/src/gui/EditorWindow/TimelinePanel/CommandViewModels/CSEc.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+
+using static EVTUI.ViewModels.FieldUtils;
+
+namespace EVTUI.ViewModels.TimelineCommands;
+
+public class CSEc : Generic
+{
+    public CSEc(DataManager config, SerialCommand command, object commandData) : base(config, command, commandData)
+    {
+        this.LongName = "Camera: Load From Asset";
+
+        this.AssetID = new IntSelectionField("Asset ID", this.Editable, this.Command.ObjectId, config.EventManager.AssetIDs);
+        this.EnableEditing = new BoolChoiceField("Enable Editing?", this.Editable, this.CommandData.Flags[0]);
+
+        // message
+        this.EnableMessageTypes = new BoolChoiceField("Specify Message Position Type?", this.Editable, this.CommandData.Flags[3]);
+        this.EnableMessageCoordinates = new BoolChoiceField("Directly Specify Message Coordinates?", this.Editable, this.CommandData.Flags[4]);
+        this.MessageCoordinateType = new StringSelectionField("Coordinate Type", this.Editable, this.MessageCoordinateTypes.Backward[this.CommandData.MessageCoordinateType], this.MessageCoordinateTypes.Keys);
+        this.MessageX = new NumRangeField("X Coordinate", this.Editable, this.CommandData.MessageCoordinates[0], -9999, 9999, 1);
+        this.MessageY = new NumRangeField("Y Coordinate", this.Editable, this.CommandData.MessageCoordinates[1], -9999, 9999, 1);
+
+        // unknown
+        this.UnkBool1 = new BoolChoiceField("Unknown #1", this.Editable, this.CommandData.Flags[2]);
+        this.UnkBool2 = new BoolChoiceField("Unknown #2", this.Editable, this.CommandData.Flags[5]);
+        this.UnkBool3 = new BoolChoiceField("Unknown #3", this.Editable, this.CommandData.UnkBool != 0);
+        this.UnkEnum = new NumEntryField("Unknown #4", this.Editable, this.CommandData.UnkEnum, 0, 2, 1);
+    }
+
+    public IntSelectionField AssetID       { get; set; }
+    public BoolChoiceField   EnableEditing { get; set; }
+
+    // message
+    public BoolChoiceField      EnableMessageCoordinates { get; set; }
+    public BoolChoiceField      EnableMessageTypes       { get; set; }
+    public StringSelectionField MessageCoordinateType    { get; set; }
+    public NumRangeField        MessageX                 { get; set; }
+    public NumRangeField        MessageY                 { get; set; }
+
+    // unknown
+    public BoolChoiceField UnkBool1 { get; set; }
+    public BoolChoiceField UnkBool2 { get; set; }
+    public BoolChoiceField UnkBool3 { get; set; }
+    public NumEntryField   UnkEnum  { get; set; }
+
+    public new void SaveChanges()
+    {
+        base.SaveChanges();
+
+        this.CommandData.Flags[0] = this.EnableEditing.Value;
+        this.CommandData.Flags[2] = this.UnkBool1.Value;
+        this.CommandData.Flags[3] = this.EnableMessageTypes.Value;
+        this.CommandData.Flags[4] = this.EnableMessageCoordinates.Value;
+        this.CommandData.Flags[5] = this.UnkBool2.Value;
+
+        this.CommandData.AssetId = this.AssetID.Choice;
+
+        this.CommandData.MessageCoordinateType = this.MessageCoordinateTypes.Forward[this.MessageCoordinateType.Choice];
+        this.CommandData.MessageCoordinates[0] = (float)this.MessageX.Value;
+        this.CommandData.MessageCoordinates[1] = (float)this.MessageY.Value;
+
+        this.CommandData.UnkBool           = Convert.ToByte(this.UnkBool3.Value);
+        this.CommandData.UnkEnum           = (byte)this.UnkEnum.Value;
+    }
+
+    public BiDict<string, uint> MessageCoordinateTypes = new BiDict<string, uint>
+    (
+        new Dictionary<string, uint>
+        {
+            {"Top Left",      0},
+            {"Top Center",    1},
+            {"Top Right",     2},
+            {"Bottom Left",   3},
+            {"Bottom Center", 4},
+            {"Bottom Right",  5},
+        }
+    );
+}

--- a/src/gui/EditorWindow/TimelinePanel/CommandViewModels/CShk.cs
+++ b/src/gui/EditorWindow/TimelinePanel/CommandViewModels/CShk.cs
@@ -1,0 +1,52 @@
+using System.Collections.Generic;
+
+using static EVTUI.ViewModels.FieldUtils;
+
+namespace EVTUI.ViewModels.TimelineCommands;
+
+public class CShk : Generic
+{
+    public CShk(DataManager config, SerialCommand command, object commandData) : base(config, command, commandData)
+    {
+        this.LongName = "Camera: Shaking Effect";
+
+        this.ActionType = new StringSelectionField("Mode", this.Editable, this.ActionTypes.Backward[this.CommandData.Action], this.ActionTypes.Keys);
+        this.ShakingType = new StringSelectionField("Effect Type", this.Editable, this.ShakingTypes.Backward[this.CommandData.ShakingType], this.ShakingTypes.Keys);
+        this.Magnitude = new NumRangeField("Magnitude", this.Editable, this.CommandData.Magnitude, 0, 100, 1);
+        this.Speed = new NumRangeField("Speed", this.Editable, this.CommandData.Speed, 0, 100, 1);
+    }
+
+    public StringSelectionField ActionType  { get; set; }
+    public StringSelectionField ShakingType { get; set; }
+    public NumRangeField        Magnitude   { get; set; }
+    public NumRangeField        Speed       { get; set; }
+
+    public new void SaveChanges()
+    {
+        base.SaveChanges();
+
+        this.CommandData.Action      = this.ActionTypes.Forward[this.ActionType.Choice];
+        this.CommandData.ShakingType = this.ShakingTypes.Forward[this.ShakingType.Choice];
+        this.CommandData.Magnitude   = (float)this.Magnitude.Value;
+        this.CommandData.Speed       = (float)this.Speed.Value;
+    }
+
+    public BiDict<string, uint> ActionTypes = new BiDict<string, uint>
+    (
+        new Dictionary<string, uint>
+        {
+            {"Shaking On",  0},
+            {"Shaking Off", 1},
+        }
+    );
+
+    public BiDict<string, uint> ShakingTypes = new BiDict<string, uint>
+    (
+        new Dictionary<string, uint>
+        {
+            {"Basic",     0},
+            {"Train Car", 1},
+            {"Close-Up",  2},
+        }
+    );
+}

--- a/src/gui/EditorWindow/TimelinePanel/CommandViewModels/CSk_.cs
+++ b/src/gui/EditorWindow/TimelinePanel/CommandViewModels/CSk_.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+
+using static EVTUI.ViewModels.FieldUtils;
+
+namespace EVTUI.ViewModels.TimelineCommands;
+
+public class CSk_ : Generic
+{
+    public CSk_(DataManager config, SerialCommand command, object commandData) : base(config, command, commandData)
+    {
+        this.LongName = "Camera: Shaking Effect (Old)";
+
+        this.VibrationType = new StringSelectionField("Vibration Mode", this.Editable, this.VibrationTypes.Backward[this.CommandData.VibrationMode], this.VibrationTypes.Keys);
+    }
+
+    public StringSelectionField VibrationType { get; set; }
+
+    public new void SaveChanges()
+    {
+        base.SaveChanges();
+
+        this.CommandData.VibrationMode = this.VibrationTypes.Forward[this.VibrationType.Choice];
+    }
+
+    public BiDict<string, uint> VibrationTypes = new BiDict<string, uint>
+    (
+        new Dictionary<string, uint>
+        {
+            {"None",   0},
+            {"Stop",   1},
+            {"Off",    2},
+            {"Low",    3},
+            {"Middle", 4},
+            {"High",   5},
+        }
+    );
+}

--- a/src/gui/EditorWindow/TimelinePanel/CommandViewModels/Generic.cs
+++ b/src/gui/EditorWindow/TimelinePanel/CommandViewModels/Generic.cs
@@ -14,6 +14,8 @@ public class Generic : ReactiveObject
         this.CommandData = commandData;
         this.Editable    = !config.ReadOnly;
         this.Basics      = new Basics(config, command);
+
+        this.Size = command.DataSize;
     }
 
     public string           LongName    { get; set; }
@@ -21,6 +23,8 @@ public class Generic : ReactiveObject
     protected dynamic       CommandData;
     public bool             Editable { get; }
     public Basics           Basics { get; set; }
+
+    public int Size { get; }
 
     public void SaveChanges()
     {

--- a/src/gui/EditorWindow/TimelinePanel/CommandViewModels/MAlp.cs
+++ b/src/gui/EditorWindow/TimelinePanel/CommandViewModels/MAlp.cs
@@ -14,22 +14,14 @@ public class MAlp : Generic
 
         this.AlphaLevel = new NumEntryField("Alpha Level", this.Editable, this.CommandData.RGBA[3], 0, 255, 1);
         this.TranslucentMode = new StringSelectionField("Translucent Mode", this.Editable, this.TranslucentModes.Backward[this.CommandData.TranslucentMode], this.TranslucentModes.Keys);
-
-        // interpolation
-        this.InterpolationType = new StringSelectionField("Interpolation Type", this.Editable, this.InterpolationTypes.Backward[(this.CommandData.InterpolationParameters & 0xFF)], this.InterpolationTypes.Keys);
-        this.SlopeInType = new StringSelectionField("Slope-In Type", this.Editable, this.SlopeTypes.Backward[((this.CommandData.InterpolationParameters >> 8) & 0xF)], this.SlopeTypes.Keys);
-        this.SlopeOutType = new StringSelectionField("Slope-Out Type", this.Editable, this.SlopeTypes.Backward[((this.CommandData.InterpolationParameters >> 12) & 0xF)], this.SlopeTypes.Keys);
+        this.InterpolationSettings = new InterpolationParameters(this.CommandData.InterpolationParameters, this.Editable);
     }
 
     public IntSelectionField AssetID { get; set; }
 
-    public NumEntryField        AlphaLevel      { get; set; }
-    public StringSelectionField TranslucentMode { get; set; }
-
-    // interpolation
-    public StringSelectionField InterpolationType { get; set; }
-    public StringSelectionField SlopeInType       { get; set; }
-    public StringSelectionField SlopeOutType      { get; set; }
+    public NumEntryField           AlphaLevel            { get; set; }
+    public StringSelectionField    TranslucentMode       { get; set; }
+    public InterpolationParameters InterpolationSettings { get; set; }
 
     public new void SaveChanges()
     {
@@ -37,34 +29,9 @@ public class MAlp : Generic
         this.Command.ObjectId = this.AssetID.Choice;
 
         this.CommandData.RGBA[3] = (byte)this.AlphaLevel.Value;
-
-        this.CommandData.InterpolationParameters = 0;
-        this.CommandData.InterpolationParameters |= this.InterpolationTypes.Forward[this.InterpolationType.Choice];
-        this.CommandData.InterpolationParameters |= (this.SlopeTypes.Forward[this.SlopeInType.Choice] << 8);
-        this.CommandData.InterpolationParameters |= (this.SlopeTypes.Forward[this.SlopeOutType.Choice] << 12);
-
+        this.CommandData.InterpolationParameters = this.InterpolationSettings.Compose();
         this.CommandData.TranslucentMode = this.TranslucentModes.Forward[this.TranslucentMode.Choice];
     }
-
-    public BiDict<string, uint> InterpolationTypes = new BiDict<string, uint>
-    (
-        new Dictionary<string, uint>
-        {
-            {"Linear",   0},
-            {"Step",     1},
-            {"Hermite",  2},
-        }
-    );
-
-    public BiDict<string, uint> SlopeTypes = new BiDict<string, uint>
-    (
-        new Dictionary<string, uint>
-        {
-            {"Normal", 0},
-            {"Slow",   1},
-            {"Fast",   2},
-        }
-    );
 
     public BiDict<string, byte> TranslucentModes = new BiDict<string, byte>
     (

--- a/src/gui/EditorWindow/TimelinePanel/TimelinePanel.axaml
+++ b/src/gui/EditorWindow/TimelinePanel/TimelinePanel.axaml
@@ -144,6 +144,18 @@
       </Button>
     </DataTemplate>
 
+    <DataTemplate DataType="{x:Type vm:InterpolationParameters}">
+      <StackPanel Classes="form">
+        <Expander Header="Interpolation">
+          <StackPanel Classes="form">
+            <ContentControl Content="{Binding InterpolationType}"/>
+            <ContentControl Content="{Binding SlopeInType}" IsVisible="{c:Binding 'InterpolationType.Choice == \'Hermite\''}"/>
+            <ContentControl Content="{Binding SlopeOutType}" IsVisible="{c:Binding 'InterpolationType.Choice == \'Hermite\''}"/>
+          </StackPanel>
+        </Expander>
+      </StackPanel>
+    </DataTemplate>
+
     <!-- COMMAND TYPES -->
 
     <DataTemplate DataType="{x:Type cmds:Basics}">
@@ -159,6 +171,340 @@
           </StackPanel>
         </Expander>
         <Separator Classes="formsubtitle"/>
+      </StackPanel>
+    </DataTemplate>
+
+    <DataTemplate DataType="{x:Type cmds:CAA_}">
+      <StackPanel Classes="form">
+        <TextBlock Classes="formtitle" Text="{Binding LongName}"/>
+        <Separator Classes="formtitle"/>
+        <ContentControl Content="{Binding Basics}"/>
+        <ContentControl Content="{Binding LoopBool}"/>
+        <ContentControl Content="{Binding EnableViewAngleUpdate}"/>
+        <Expander Header="Animation Source">
+          <StackPanel Classes="form">
+            <ContentControl Content="{Binding AssetID}"/>
+            <ContentControl Content="{Binding AnimationID}"/>
+            <ContentControl Content="{Binding PlaybackSpeed}"/>
+          </StackPanel>
+        </Expander>
+      </StackPanel>
+    </DataTemplate>
+
+    <DataTemplate DataType="{x:Type cmds:CAR_}">
+      <StackPanel Classes="form">
+        <TextBlock Classes="formtitle" Text="{Binding LongName}"/>
+        <Separator Classes="formtitle"/>
+        <ContentControl Content="{Binding Basics}"/>
+        <ContentControl Content="{Binding ResetCommand}"/>
+        <ContentControl Content="{Binding ResetParameters}"/>
+      </StackPanel>
+    </DataTemplate>
+
+    <DataTemplate DataType="{x:Type cmds:CClp}">
+      <StackPanel Classes="form">
+        <TextBlock Classes="formtitle" Text="{Binding LongName}"/>
+        <Separator Classes="formtitle"/>
+        <ContentControl Content="{Binding Basics}"/>
+        <ContentControl Content="{Binding NearClip}"/>
+        <ContentControl Content="{Binding FarClip}"/>
+      </StackPanel>
+    </DataTemplate>
+
+    <DataTemplate DataType="{x:Type cmds:CMC_}">
+      <StackPanel Classes="form">
+        <TextBlock Classes="formtitle" Text="{Binding LongName}"/>
+        <Separator Classes="formtitle"/>
+        <ContentControl Content="{Binding Basics}"/>
+        <ContentControl Content="{Binding AssetID}"/>
+        <ContentControl Content="{Binding ShotType}"/>
+        <ContentControl Content="{Binding AngleType}"/>
+        <ContentControl Content="{Binding StartCorrectionFrame}"/>
+        <ContentControl Content="{Binding InterpolationSettings}"/>
+        <Expander Header="Focus &amp; Blur">
+          <StackPanel Classes="form">
+            <ContentControl Content="{Binding EnableDOF}"/>
+            <StackPanel Classes="form" IsVisible="{Binding EnableDOF.Value}">
+              <ContentControl Content="{Binding EnableCustomDOF}"/>
+              <StackPanel Classes="form" IsVisible="{Binding EnableCustomDOF.Value}">
+                <ContentControl Content="{Binding FocalDistance}"/>
+                <ContentControl Content="{Binding NearBlurDistance}"/>
+                <ContentControl Content="{Binding FarBlurDistance}"/>
+                <ContentControl Content="{Binding BlurStrength}"/>
+                <ContentControl Content="{Binding BlurType}" IsVisible="{c:Binding 'Size > 48'}"/>
+              </StackPanel>
+            </StackPanel>
+          </StackPanel>
+        </Expander>
+        <Expander Header="Message Box Location" IsVisible="{c:Binding 'Size > 48'}">
+          <StackPanel Classes="form">
+            <ContentControl Content="{Binding EnableMessageCoordinates}"/>
+            <ContentControl Content="{Binding MessageCoordinateType}" IsVisible="{Binding !EnableMessageCoordinates.Value}"/>
+            <ContentControl Content="{Binding MessageX}" IsVisible="{Binding EnableMessageCoordinates.Value}"/>
+            <ContentControl Content="{Binding MessageY}" IsVisible="{Binding EnableMessageCoordinates.Value}"/>
+          </StackPanel>
+        </Expander>
+      </StackPanel>
+    </DataTemplate>
+
+    <DataTemplate DataType="{x:Type cmds:CMCn}">
+      <StackPanel Classes="form">
+        <TextBlock Classes="formtitle" Text="{Binding LongName}"/>
+        <Separator Classes="formtitle"/>
+        <ContentControl Content="{Binding Basics}"/>
+        <ContentControl Content="{Binding DirectionType}"/>
+        <ContentControl Content="{Binding Distance}"/>
+      </StackPanel>
+    </DataTemplate>
+
+    <DataTemplate DataType="{x:Type cmds:CMD_}">
+      <StackPanel Classes="form">
+        <TextBlock Classes="formtitle" Text="{Binding LongName}"/>
+        <Separator Classes="formtitle"/>
+        <ContentControl Content="{Binding Basics}"/>
+        <ContentControl Content="{Binding AngleOfView}"/>
+        <Expander Header="Target Viewport Coordinates">
+          <StackPanel Classes="form">
+            <ContentControl Content="{Binding ViewportX}"/>
+            <ContentControl Content="{Binding ViewportY}"/>
+            <ContentControl Content="{Binding ViewportZ}"/>
+          </StackPanel>
+        </Expander>
+        <Expander Header="Target Viewport Rotation">
+          <StackPanel Classes="form">
+            <ContentControl Content="{Binding ViewportYaw}"/>
+            <ContentControl Content="{Binding ViewportPitch}"/>
+            <ContentControl Content="{Binding ViewportRoll}"/>
+          </StackPanel>
+        </Expander>
+        <ContentControl Content="{Binding InterpolationSettings}"/>
+        <Expander Header="Focus &amp; Blur">
+          <StackPanel Classes="form">
+            <ContentControl Content="{Binding EnableDOF}"/>
+            <StackPanel Classes="form" IsVisible="{Binding EnableDOF.Value}">
+              <ContentControl Content="{Binding FocalDistance}"/>
+              <ContentControl Content="{Binding NearBlurDistance}"/>
+              <ContentControl Content="{Binding FarBlurDistance}"/>
+              <ContentControl Content="{Binding BlurStrength}" IsVisible="{c:Binding 'Size > 48'}"/>
+              <ContentControl Content="{Binding BlurType}" IsVisible="{c:Binding 'Size > 48'}"/>
+            </StackPanel>
+          </StackPanel>
+        </Expander>
+      </StackPanel>
+    </DataTemplate>
+
+    <DataTemplate DataType="{x:Type cmds:CQuk}">
+      <StackPanel Classes="form">
+        <TextBlock Classes="formtitle" Text="{Binding LongName}"/>
+        <Separator Classes="formtitle"/>
+        <ContentControl Content="{Binding Basics}"/>
+        <ContentControl Content="{Binding StrengthOfShaking}"/>
+        <ContentControl Content="{Binding DegreeOfPitch}"/>
+        <ContentControl Content="{Binding FadeInFrames}"/>
+        <ContentControl Content="{Binding FadeOutFrames}"/>
+      </StackPanel>
+    </DataTemplate>
+
+    <DataTemplate DataType="{x:Type cmds:CSA_}">
+      <StackPanel Classes="form">
+        <TextBlock Classes="formtitle" Text="{Binding LongName}"/>
+        <Separator Classes="formtitle"/>
+        <ContentControl Content="{Binding Basics}"/>
+        <ContentControl Content="{Binding AssetID}"/>
+        <ContentControl Content="{Binding AnimationID}"/>
+        <ContentControl Content="{Binding PlaybackSpeed}"/>
+        <ContentControl Content="{Binding StartingFrame}"/>
+        <ContentControl Content="{Binding LoopBool}"/>
+        <ContentControl Content="{Binding EnableCorrectionParameters}"/>
+        <Expander Header="Target Viewport Coordinates" IsVisible="{Binding EnableCorrectionParameters.Value}">
+          <StackPanel Classes="form">
+            <ContentControl Content="{Binding ViewportX}"/>
+            <ContentControl Content="{Binding ViewportY}"/>
+            <ContentControl Content="{Binding ViewportZ}"/>
+          </StackPanel>
+        </Expander>
+        <Expander Header="Target Viewport Rotation" IsVisible="{Binding EnableCorrectionParameters.Value}">
+          <StackPanel Classes="form">
+            <ContentControl Content="{Binding ViewportYaw}"/>
+            <ContentControl Content="{Binding ViewportPitch}"/>
+            <ContentControl Content="{Binding ViewportRoll}"/>
+          </StackPanel>
+        </Expander>
+        <Expander Header="Focus &amp; Blur" IsVisible="{c:Binding 'Size > 48'}">
+          <StackPanel Classes="form">
+            <ContentControl Content="{Binding EnableDOF}"/>
+            <StackPanel Classes="form" IsVisible="{Binding EnableDOF.Value}">
+              <ContentControl Content="{Binding FocalDistance}"/>
+              <ContentControl Content="{Binding NearBlurDistance}"/>
+              <ContentControl Content="{Binding FarBlurDistance}"/>
+              <ContentControl Content="{Binding BlurStrength}"/>
+              <ContentControl Content="{Binding BlurType}"/>
+            </StackPanel>
+          </StackPanel>
+        </Expander>
+        <Expander Header="Message Box Location" IsVisible="{c:Binding 'Size > 48'}">
+          <StackPanel Classes="form">
+            <ContentControl Content="{Binding EnableMessageCoordinates}"/>
+            <ContentControl Content="{Binding MessageCoordinateType}" IsVisible="{Binding !EnableMessageCoordinates.Value}"/>
+            <ContentControl Content="{Binding MessageX}" IsVisible="{Binding EnableMessageCoordinates.Value}"/>
+            <ContentControl Content="{Binding MessageY}" IsVisible="{Binding EnableMessageCoordinates.Value}"/>
+          </StackPanel>
+        </Expander>
+        <Expander Header="Unknown" IsVisible="{c:Binding 'Size > 80'}">
+          <StackPanel Classes="form">
+            <ContentControl Content="{Binding UnkBool}"/>
+            <ContentControl Content="{Binding UnkEnum}"/>
+            <ContentControl Content="{Binding UnkInd}"/>
+          </StackPanel>
+        </Expander>
+      </StackPanel>
+    </DataTemplate>
+
+    <DataTemplate DataType="{x:Type cmds:CSD_}">
+      <StackPanel Classes="form">
+        <TextBlock Classes="formtitle" Text="{Binding LongName}"/>
+        <Separator Classes="formtitle"/>
+        <ContentControl Content="{Binding Basics}"/>
+        <ContentControl Content="{Binding AngleOfView}"/>
+        <Expander Header="Target Viewport Coordinates">
+          <StackPanel Classes="form">
+            <ContentControl Content="{Binding ViewportX}"/>
+            <ContentControl Content="{Binding ViewportY}"/>
+            <ContentControl Content="{Binding ViewportZ}"/>
+          </StackPanel>
+        </Expander>
+        <Expander Header="Target Viewport Rotation">
+          <StackPanel Classes="form">
+            <ContentControl Content="{Binding ViewportYaw}"/>
+            <ContentControl Content="{Binding ViewportPitch}"/>
+            <ContentControl Content="{Binding ViewportRoll}"/>
+          </StackPanel>
+        </Expander>
+        <Expander Header="Focus &amp; Blur" IsVisible="{c:Binding 'Size > 32'}">
+          <StackPanel Classes="form">
+            <ContentControl Content="{Binding EnableDOF}"/>
+            <StackPanel Classes="form" IsVisible="{Binding EnableDOF.Value}">
+              <ContentControl Content="{Binding FocalDistance}"/>
+              <ContentControl Content="{Binding NearBlurDistance}"/>
+              <ContentControl Content="{Binding FarBlurDistance}"/>
+              <ContentControl Content="{Binding BlurStrength}"/>
+              <ContentControl Content="{Binding BlurType}" IsVisible="{c:Binding 'Size > 48'}"/>
+            </StackPanel>
+          </StackPanel>
+        </Expander>
+        <Expander Header="Message Box Location" IsVisible="{c:Binding 'Size > 48'}">
+          <StackPanel Classes="form">
+            <ContentControl Content="{Binding EnableMessageCoordinates}"/>
+            <ContentControl Content="{Binding MessageCoordinateType}" IsVisible="{Binding !EnableMessageCoordinates.Value}"/>
+            <ContentControl Content="{Binding MessageX}" IsVisible="{Binding EnableMessageCoordinates.Value}"/>
+            <ContentControl Content="{Binding MessageY}" IsVisible="{Binding EnableMessageCoordinates.Value}"/>
+          </StackPanel>
+        </Expander>
+        <Expander Header="Unknown" IsVisible="{c:Binding 'Size > 64'}">
+          <StackPanel Classes="form">
+            <ContentControl Content="{Binding UnkBool}"/>
+            <ContentControl Content="{Binding UnkEnum}"/>
+            <ContentControl Content="{Binding UnkInd}"/>
+            <ContentControl Content="{Binding SuperUnk1}"/>
+            <ContentControl Content="{Binding SuperUnk2}"/>
+            <ContentControl Content="{Binding UnkCoord1}"/>
+            <ContentControl Content="{Binding UnkCoord2}"/>
+            <ContentControl Content="{Binding UnkCoord3}"/>
+          </StackPanel>
+        </Expander>
+      </StackPanel>
+    </DataTemplate>
+
+    <DataTemplate DataType="{x:Type cmds:CSDD}">
+      <StackPanel Classes="form">
+        <TextBlock Classes="formtitle" Text="{Binding LongName}"/>
+        <Separator Classes="formtitle"/>
+        <ContentControl Content="{Binding Basics}"/>
+        <ContentControl Content="{Binding AngleOfView}"/>
+        <Expander Header="Target Viewport Coordinates">
+          <StackPanel Classes="form">
+            <ContentControl Content="{Binding ViewportX}"/>
+            <ContentControl Content="{Binding ViewportY}"/>
+            <ContentControl Content="{Binding ViewportZ}"/>
+          </StackPanel>
+        </Expander>
+        <Expander Header="Target Viewport Rotation">
+          <StackPanel Classes="form">
+            <ContentControl Content="{Binding ViewportYaw}"/>
+            <ContentControl Content="{Binding ViewportPitch}"/>
+            <ContentControl Content="{Binding ViewportRoll}"/>
+          </StackPanel>
+        </Expander>
+        <Expander Header="Focus &amp; Blur">
+          <StackPanel Classes="form">
+            <ContentControl Content="{Binding EnableDOF}"/>
+            <StackPanel Classes="form" IsVisible="{Binding EnableDOF.Value}">
+              <ContentControl Content="{Binding FocalDistance}"/>
+              <ContentControl Content="{Binding NearBlurDistance}"/>
+              <ContentControl Content="{Binding FarBlurDistance}"/>
+              <ContentControl Content="{Binding BlurStrength}"/>
+            </StackPanel>
+          </StackPanel>
+        </Expander>
+        <Expander Header="Unknown">
+          <StackPanel Classes="form">
+            <ContentControl Content="{Binding UnkBool}"/>
+          </StackPanel>
+        </Expander>
+      </StackPanel>
+    </DataTemplate>
+
+    <DataTemplate DataType="{x:Type cmds:CSEc}">
+      <StackPanel Classes="form">
+        <TextBlock Classes="formtitle" Text="{Binding LongName}"/>
+        <Separator Classes="formtitle"/>
+        <ContentControl Content="{Binding Basics}"/>
+        <ContentControl Content="{Binding AssetID}"/>
+        <ContentControl Content="{Binding EnableEditing}"/>
+        <Expander Header="Message Box Location" IsVisible="{Binding EnableEditing.Value}">
+          <StackPanel Classes="form">
+            <ContentControl Content="{Binding EnableMessageCoordinates}"/>
+            <StackPanel Classes="form" IsVisible="{Binding !EnableMessageCoordinates.Value}">
+              <ContentControl Content="{Binding EnableMessageTypes}"/>
+              <ContentControl Content="{Binding MessageCoordinateType}" IsVisible="{Binding EnableMessageTypes.Value}"/>
+            </StackPanel>
+            <StackPanel Classes="form" IsVisible="{Binding EnableMessageCoordinates.Value}">
+              <ContentControl Content="{Binding MessageX}"/>
+              <ContentControl Content="{Binding MessageY}"/>
+            </StackPanel>
+          </StackPanel>
+        </Expander>
+        <Expander Header="Unknown">
+          <StackPanel Classes="form">
+            <ContentControl Content="{Binding UnkBool1}"/>
+            <ContentControl Content="{Binding UnkBool2}"/>
+            <ContentControl Content="{Binding UnkBool3}"/>
+            <ContentControl Content="{Binding UnkEnum}"/>
+          </StackPanel>
+        </Expander>
+      </StackPanel>
+    </DataTemplate>
+
+    <DataTemplate DataType="{x:Type cmds:CShk}">
+      <StackPanel Classes="form">
+        <TextBlock Classes="formtitle" Text="{Binding LongName}"/>
+        <Separator Classes="formtitle"/>
+        <ContentControl Content="{Binding Basics}"/>
+        <ContentControl Content="{Binding ActionType}"/>
+        <StackPanel Classes="form" IsVisible="{c:Binding 'ActionType.Choice == \'Shaking On\''}">
+          <ContentControl Content="{Binding ShakingType}"/>
+          <ContentControl Content="{Binding Magnitude}"/>
+          <ContentControl Content="{Binding Speed}"/>
+        </StackPanel>
+      </StackPanel>
+    </DataTemplate>
+
+    <DataTemplate DataType="{x:Type cmds:CSk_}">
+      <StackPanel Classes="form">
+        <TextBlock Classes="formtitle" Text="{Binding LongName}"/>
+        <Separator Classes="formtitle"/>
+        <ContentControl Content="{Binding Basics}"/>
+        <ContentControl Content="{Binding VibrationType}"/>
       </StackPanel>
     </DataTemplate>
 
@@ -249,13 +595,7 @@
         <ContentControl Content="{Binding AssetID}"/>
         <ContentControl Content="{Binding AlphaLevel}"/>
         <ContentControl Content="{Binding TranslucentMode}"/>
-        <Expander Header="Interpolation">
-          <StackPanel Classes="form">
-            <ContentControl Content="{Binding InterpolationType}"/>
-            <ContentControl Content="{Binding SlopeInType}" IsVisible="{c:Binding 'InterpolationType.Choice == \'Hermite\''}"/>
-            <ContentControl Content="{Binding SlopeOutType}" IsVisible="{c:Binding 'InterpolationType.Choice == \'Hermite\''}"/>
-          </StackPanel>
-        </Expander>
+        <ContentControl Content="{Binding InterpolationSettings}"/>
       </StackPanel>
     </DataTemplate>
 

--- a/src/gui/Utilities/FieldViewModels.cs
+++ b/src/gui/Utilities/FieldViewModels.cs
@@ -223,7 +223,7 @@ public class ColorSelectionField : FieldBase
 
 public class AnimationWidget : ViewModelBase
 {
-    public AnimationWidget(DataManager config, IntSelectionField modelID, AnimationStruct animation, Bitfield bitfield, string name, int? enabledInd = null, int? extInd = null, int? frameBlendingInd = null, bool enabledFlip = false, bool extFlip = false, bool frameBlendingFlip = false, bool loopFlip = false, int? trackNum = null)
+    public AnimationWidget(DataManager config, IntSelectionField modelID, AnimationStruct animation, BitfieldBase bitfield, string name, int? enabledInd = null, int? extInd = null, int? frameBlendingInd = null, bool enabledFlip = false, bool extFlip = false, bool frameBlendingFlip = false, bool loopFlip = false, int? trackNum = null)
     {
         _config = config;
         _modelID = modelID;
@@ -328,7 +328,7 @@ public class AnimationWidget : ViewModelBase
     private int _objectID { get => (int)_modelID.Choice; }
 
     protected DataManager _config;
-    protected Bitfield _bitfield;
+    protected BitfieldBase _bitfield;
     public AnimationStruct _animation;
     protected int? _enabledInd;
     protected int? _extInd;

--- a/src/gui/Utilities/FieldViewModels.cs
+++ b/src/gui/Utilities/FieldViewModels.cs
@@ -405,3 +405,52 @@ public class ModelPreviewWidget : ViewModelBase
 
     protected DataManager _config;
 }
+
+public class InterpolationParameters : ViewModelBase
+{
+    private uint Field;
+    private bool Editable;
+
+    public StringSelectionField InterpolationType { get; set; }
+    public StringSelectionField SlopeInType       { get; set; }
+    public StringSelectionField SlopeOutType      { get; set; }
+
+    public InterpolationParameters(uint field, bool editable)
+    {
+        this.Field = field;
+        this.Editable = editable;
+
+        this.InterpolationType = new StringSelectionField("Interpolation Type", this.Editable, this.InterpolationTypes.Backward[(this.Field & 0xFF)], this.InterpolationTypes.Keys);
+        this.SlopeInType = new StringSelectionField("Slope-In Type", this.Editable, this.SlopeTypes.Backward[((this.Field >> 8) & 0xF)], this.SlopeTypes.Keys);
+        this.SlopeOutType = new StringSelectionField("Slope-Out Type", this.Editable, this.SlopeTypes.Backward[((this.Field >> 12) & 0xF)], this.SlopeTypes.Keys);
+    }
+
+    public uint Compose()
+    {
+        this.Field = 0;
+        this.Field |= this.InterpolationTypes.Forward[this.InterpolationType.Choice];
+        this.Field |= (this.SlopeTypes.Forward[this.SlopeInType.Choice] << 8);
+        this.Field |= (this.SlopeTypes.Forward[this.SlopeOutType.Choice] << 12);
+        return this.Field;
+    }
+
+    public BiDict<string, uint> InterpolationTypes = new BiDict<string, uint>
+    (
+        new Dictionary<string, uint>
+        {
+            {"Linear",   0},
+            {"Step",     1},
+            {"Hermite",  2},
+        }
+    );
+
+    public BiDict<string, uint> SlopeTypes = new BiDict<string, uint>
+    (
+        new Dictionary<string, uint>
+        {
+            {"Normal", 0},
+            {"Slow",   1},
+            {"Fast",   2},
+        }
+    );
+}

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/CAA_.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/CAA_.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using Serialization;
+
+namespace EVTUI;
+
+public partial class CommandTypes
+{
+    public class CAA_ : ISerializable
+    {
+        public const int DataSize = 48;
+
+        public Bitfield32 Flags = new Bitfield32();
+        public Int32 AssetId;
+        public UInt32 AnimationId;
+        public float PlaybackSpeed = 1.0F;
+
+        public UInt32[] UNUSED_UINT32 = new UInt32[8];
+
+        public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
+        {
+            rw.RwObj(ref this.Flags);
+            rw.RwInt32(ref this.AssetId);
+            rw.RwUInt32(ref this.AnimationId);
+            rw.RwFloat32(ref this.PlaybackSpeed);
+
+            for (int i=0; i<this.UNUSED_UINT32.Length; i++)
+            {
+                rw.RwUInt32(ref this.UNUSED_UINT32[i]);
+                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
+            }
+        }
+    }
+}

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/CAR_.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/CAR_.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using Serialization;
+
+namespace EVTUI;
+
+public partial class CommandTypes
+{
+    public class CAR_ : ISerializable
+    {
+        public const int DataSize = 16;
+
+        public Bitfield32 Flags = new Bitfield32(3);
+
+        public UInt32[] UNUSED_UINT32 = new UInt32[3];
+
+        public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
+        {
+            rw.RwObj(ref this.Flags);
+
+            for (int i=0; i<this.UNUSED_UINT32.Length; i++)
+            {
+                rw.RwUInt32(ref this.UNUSED_UINT32[i]);
+                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
+            }
+        }
+    }
+}

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/CClp.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/CClp.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using Serialization;
+
+namespace EVTUI;
+
+public partial class CommandTypes
+{
+    public class CClp : ISerializable
+    {
+        public const int DataSize = 16;
+
+        public float NearClip = 1.0F;
+        public float FarClip  = 60000.0F;
+
+        public UInt32[] UNUSED_UINT32 = new UInt32[2];
+
+        public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
+        {
+            for (int i=0; i<this.UNUSED_UINT32.Length; i++)
+            {
+                rw.RwUInt32(ref this.UNUSED_UINT32[i]);
+                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
+            }
+
+            rw.RwFloat32(ref this.NearClip);
+            rw.RwFloat32(ref this.FarClip);
+        }
+    }
+}

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/CMC_.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/CMC_.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using Serialization;
+
+namespace EVTUI;
+
+public partial class CommandTypes
+{
+    public class CMC_ : ISerializable
+    {
+        public const int DataSize = 64;
+
+        public Bitfield32 Flags = new Bitfield32();
+
+        public UInt32 InterpolationParameters = 4354;
+        public UInt16 StartCorrectionFrameNumber;
+        public Int32 AssetId;
+        public UInt32 ShotType;
+        public UInt32 AngleType;
+
+        public float FocalPlaneDistance;
+        public float NearBlurSurface;
+        public float FarBlurSurface;
+        public float BlurStrength = 1.0F;
+
+        public UInt32 BlurType;
+        public UInt32 MessageCoordinateType = 4;
+        public float[] MessageCoordinates = new[] { 375.0F, 528.0F };
+
+        public UInt16[] UNUSED_UINT16 = new UInt16[1];
+        public UInt32[] UNUSED_UINT32 = new UInt32[2];
+
+        public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
+        {
+            rw.RwObj(ref this.Flags);
+
+            rw.RwUInt32(ref this.InterpolationParameters);
+            rw.RwUInt16(ref this.StartCorrectionFrameNumber);
+
+            rw.RwUInt16(ref this.UNUSED_UINT16[0]);
+            Trace.Assert(this.UNUSED_UINT16[0] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT16[0]}) in reserve variable.");
+
+            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
+
+            rw.RwInt32(ref this.AssetId);
+            rw.RwUInt32(ref this.ShotType);
+
+            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
+
+            rw.RwUInt32(ref this.AngleType);
+
+            rw.RwFloat32(ref this.FocalPlaneDistance);
+            rw.RwFloat32(ref this.NearBlurSurface);
+            rw.RwFloat32(ref this.FarBlurSurface);
+            rw.RwFloat32(ref this.BlurStrength);
+
+            if ((int)args["dataSize"] > 48)
+            {
+                rw.RwUInt32(ref this.BlurType);
+                rw.RwUInt32(ref this.MessageCoordinateType);
+                rw.RwFloat32s(ref this.MessageCoordinates, 2);
+            }
+
+            for (int i=0; i<this.UNUSED_UINT32.Length; i++)
+                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
+        }
+    }
+}

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/CMCn.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/CMCn.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using Serialization;
+
+namespace EVTUI;
+
+public partial class CommandTypes
+{
+    public class CMCn : ISerializable
+    {
+        public const int DataSize = 16;
+
+        public UInt32 DirectionType;
+        public float Distance;
+
+        public UInt32[] UNUSED_UINT32 = new UInt32[2];
+
+        public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
+        {
+            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
+            Trace.Assert(this.UNUSED_UINT32[0] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[0]}) in reserve variable.");
+
+            rw.RwUInt32(ref this.DirectionType);
+            rw.RwFloat32(ref this.Distance);
+
+            rw.RwUInt32(ref this.UNUSED_UINT32[1]);
+            Trace.Assert(this.UNUSED_UINT32[1] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[1]}) in reserve variable.");
+        }
+    }
+}

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/CMD_.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/CMD_.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using Serialization;
+
+namespace EVTUI;
+
+public partial class CommandTypes
+{
+    public class CMD_ : ISerializable
+    {
+        public const int DataSize = 64;
+
+        public Bitfield32 Flags = new Bitfield32(15);
+
+        public float[] ViewportCoordinates = new float[3];
+        public float[] ViewportRotation = new float[3];
+        public float AngleOfView = 45.0F;
+
+        public UInt32 InterpolationParameters = 4354;
+
+        public float FocalPlaneDistance;
+        public float NearBlurSurface;
+        public float FarBlurSurface;
+
+        public float BlurStrength = 1.0F;
+        public UInt32 BlurType;
+
+        public UInt32[] UNUSED_UINT32 = new UInt32[2];
+
+        public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
+        {
+            rw.RwObj(ref this.Flags);
+
+            rw.RwFloat32s(ref this.ViewportCoordinates, 3);
+            rw.RwFloat32s(ref this.ViewportRotation, 3);
+            rw.RwFloat32(ref this.AngleOfView);
+
+            rw.RwUInt32(ref this.InterpolationParameters);
+
+            rw.RwFloat32(ref this.FocalPlaneDistance);
+            rw.RwFloat32(ref this.NearBlurSurface);
+            rw.RwFloat32(ref this.FarBlurSurface);
+
+            if ((int)args["dataSize"] > 48)
+            {
+                rw.RwFloat32(ref this.BlurStrength);
+                rw.RwUInt32(ref this.BlurType);
+
+                for (int i=0; i<this.UNUSED_UINT32.Length; i++)
+                {
+                    rw.RwUInt32(ref this.UNUSED_UINT32[i]);
+                    Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
+                }
+            }
+        }
+    }
+}

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/CQuk.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/CQuk.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using Serialization;
+
+namespace EVTUI;
+
+public partial class CommandTypes
+{
+	public class CQuk : ISerializable
+	{
+		public const int DataSize = 32;
+
+		public float StrengthOfShaking;
+		public float DegreeOfPitch;
+		public UInt32 FadeInFrames;
+		public UInt32 FadeOutFrames;
+
+        public UInt32[] UNUSED_UINT32 = new UInt32[4];
+
+		public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
+		{
+            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
+            Trace.Assert(this.UNUSED_UINT32[0] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[0]}) in reserve variable.");
+
+			rw.RwFloat32(ref this.StrengthOfShaking);
+			rw.RwFloat32(ref this.DegreeOfPitch);
+			rw.RwUInt32(ref this.FadeInFrames);
+			rw.RwUInt32(ref this.FadeOutFrames);
+
+            for (int i=1; i<this.UNUSED_UINT32.Length; i++)
+            {
+                rw.RwUInt32(ref this.UNUSED_UINT32[i]);
+                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
+            }
+		}
+	}
+}
+

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/CSA_.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/CSA_.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using Serialization;
+
+namespace EVTUI;
+
+public partial class CommandTypes
+{
+    public class CSA_ : ISerializable
+    {
+        public const int DataSize = 96;
+
+        public Bitfield32 Flags = new Bitfield32(48);
+
+        public Int32 AssetId;
+        public UInt32 AnimationId;
+        public float PlaybackSpeed = 1.0F;
+        public UInt32 StartingFrame;
+
+        public float[] ViewportCoordinates = new float[3];
+        public float[] ViewportRotation = new float[3];
+
+        public float FocalPlaneDistance;
+        public float NearBlurSurface;
+        public float FarBlurSurface;
+
+        public float BlurStrength = 1.0F;
+        public UInt32 BlurType;
+
+        public UInt32 MessageCoordinateType = 4;
+        public float[] MessageCoordinates = new[] { 375.0F, 565.0F };
+
+        public byte UnkEnum;
+        public byte UnkInd = 2;
+
+        public UInt16[] UNUSED_UINT16 = new UInt16[1];
+        public UInt32[] UNUSED_UINT32 = new UInt32[4];
+
+        public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
+        {
+            rw.RwObj(ref this.Flags);
+
+            rw.RwInt32(ref this.AssetId);
+            rw.RwUInt32(ref this.AnimationId);
+            rw.RwFloat32(ref this.PlaybackSpeed);
+            rw.RwUInt32(ref this.StartingFrame);
+
+            rw.RwFloat32s(ref this.ViewportCoordinates, 3);
+            rw.RwFloat32s(ref this.ViewportRotation, 3);
+
+            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
+            Trace.Assert(this.UNUSED_UINT32[0] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[0]}) in reserve variable.");
+
+            if ((int)args["dataSize"] > 48)
+            {
+                rw.RwFloat32(ref this.FocalPlaneDistance);
+                rw.RwFloat32(ref this.NearBlurSurface);
+                rw.RwFloat32(ref this.FarBlurSurface);
+
+                rw.RwFloat32(ref this.BlurStrength);
+                rw.RwUInt32(ref this.BlurType);
+
+                rw.RwUInt32(ref this.MessageCoordinateType);
+                rw.RwFloat32s(ref this.MessageCoordinates, 2);
+
+                if ((int)args["dataSize"] > 80)
+                {
+                    rw.RwUInt8(ref this.UnkEnum);
+                    rw.RwUInt8(ref this.UnkInd);
+
+                    rw.RwUInt16(ref this.UNUSED_UINT16[0]);
+                    Trace.Assert(this.UNUSED_UINT16[0] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT16[0]}) in reserve variable.");
+
+                    for (int i=1; i<this.UNUSED_UINT32.Length; i++)
+                    {
+                        rw.RwUInt32(ref this.UNUSED_UINT32[i]);
+                        Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/CSDD.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/CSDD.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using Serialization;
+
+namespace EVTUI;
+
+public partial class CommandTypes
+{
+    public class CSDD : ISerializable
+    {
+        public const int DataSize = 48;
+
+        public Bitfield32 Flags = new Bitfield32(2);
+
+        public float[] ViewportCoordinates = new float[3];
+        public float[] ViewportRotation = new float[3];
+        public float AngleOfView = 45.0F;
+
+        public float FocalPlaneDistance;
+        public float NearBlurSurface;
+        public float FarBlurSurface;
+        public float BlurStrength = 1.0F;
+
+        public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
+        {
+            rw.RwObj(ref this.Flags);
+
+            rw.RwFloat32s(ref this.ViewportCoordinates, 3);
+            rw.RwFloat32s(ref this.ViewportRotation, 3);
+            rw.RwFloat32(ref this.AngleOfView);
+
+            rw.RwFloat32(ref this.FocalPlaneDistance);
+            rw.RwFloat32(ref this.NearBlurSurface);
+            rw.RwFloat32(ref this.FarBlurSurface);
+            rw.RwFloat32(ref this.BlurStrength);
+        }
+    }
+}

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/CSD_.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/CSD_.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using Serialization;
+
+namespace EVTUI;
+
+public partial class CommandTypes
+{
+    public class CSD_ : ISerializable
+    {
+        public const int DataSize = 80;
+
+        public Bitfield32 Flags = new Bitfield32(16);
+
+        public float[] ViewportCoordinates = new float[3];
+        public float[] ViewportRotation = new float[3];
+        public float AngleOfView = 45.0F;
+
+        public float FocalPlaneDistance;
+        public float NearBlurSurface;
+        public float FarBlurSurface;
+
+        public float BlurStrength = 1.0F;
+        public UInt32 BlurType;
+
+        public UInt32 MessageCoordinateType = 4;
+        public float[] MessageCoordinates = new[] { 375.0F, 528.0F };
+
+        public byte UnkEnum;
+        public byte UnkInd = 2;
+        public byte SuperUnk1;
+        public byte SuperUnk2;
+        public float[] UnkCoordinates = new float[3];
+
+        public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
+        {
+            rw.RwObj(ref this.Flags);
+
+            rw.RwFloat32s(ref this.ViewportCoordinates, 3);
+            rw.RwFloat32s(ref this.ViewportRotation, 3);
+            rw.RwFloat32(ref this.AngleOfView);
+
+            if ((int)args["dataSize"] > 32)
+            {
+                rw.RwFloat32(ref this.FocalPlaneDistance);
+                rw.RwFloat32(ref this.NearBlurSurface);
+                rw.RwFloat32(ref this.FarBlurSurface);
+                rw.RwFloat32(ref this.BlurStrength);
+
+                if ((int)args["dataSize"] > 48)
+                {
+                    rw.RwUInt32(ref this.BlurType);
+                    rw.RwUInt32(ref this.MessageCoordinateType);
+                    rw.RwFloat32s(ref this.MessageCoordinates, 2);
+
+                    if ((int)args["dataSize"] > 64)
+                    {
+                        rw.RwUInt8(ref this.UnkEnum);
+                        rw.RwUInt8(ref this.UnkInd);
+                        rw.RwUInt8(ref this.SuperUnk1);
+                        rw.RwUInt8(ref this.SuperUnk2);
+                        rw.RwFloat32s(ref this.UnkCoordinates, 3);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/CSEc.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/CSEc.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using Serialization;
+
+namespace EVTUI;
+
+public partial class CommandTypes
+{
+	public class CSEc : ISerializable
+	{
+		public const int DataSize = 32;
+
+		public Bitfield32 Flags = new Bitfield32(38);
+
+		public Int32 AssetId;
+
+		public UInt32 MessageCoordinateType = 4;
+		public float[] MessageCoordinates = new[] { 375.0F, 528.0F };
+
+		public byte UnkBool;
+		public byte UnkEnum;
+
+        public UInt16[] UNUSED_UINT16 = new UInt16[1];
+        public UInt32[] UNUSED_UINT32 = new UInt32[2];
+
+		public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
+		{
+			rw.RwObj(ref this.Flags);
+
+			rw.RwInt32(ref this.AssetId);
+
+            for (int i=0; i<this.UNUSED_UINT32.Length; i++)
+            {
+                rw.RwUInt32(ref this.UNUSED_UINT32[i]);
+                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
+            }
+
+			rw.RwUInt32(ref this.MessageCoordinateType);
+			rw.RwFloat32s(ref this.MessageCoordinates, 2);
+
+			rw.RwUInt8(ref this.UnkBool);
+			rw.RwUInt8(ref this.UnkEnum);
+
+            rw.RwUInt16(ref this.UNUSED_UINT16[0]);
+            Trace.Assert(this.UNUSED_UINT16[0] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT16[0]}) in reserve variable.");
+		}
+	}
+}
+

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/CShk.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/CShk.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using Serialization;
+
+namespace EVTUI;
+
+public partial class CommandTypes
+{
+	public class CShk : ISerializable
+	{
+		public const int DataSize = 32;
+
+        public UInt32 Action;
+        public UInt32 ShakingType;
+
+        public float Magnitude = 1.0F;
+        public float Speed     = 1.0F;
+
+        public UInt32[] UNUSED_UINT32 = new UInt32[4];
+
+		public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
+		{
+            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
+            Trace.Assert(this.UNUSED_UINT32[0] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[0]}) in reserve variable.");
+
+			rw.RwUInt32(ref this.Action);
+			rw.RwUInt32(ref this.ShakingType);
+
+			rw.RwFloat32(ref this.Magnitude);
+			rw.RwFloat32(ref this.Speed);
+
+            for (int i=1; i<this.UNUSED_UINT32.Length; i++)
+            {
+                rw.RwUInt32(ref this.UNUSED_UINT32[i]);
+                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
+            }
+		}
+	}
+}
+

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/CSk_.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/CSk_.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using Serialization;
+
+namespace EVTUI;
+
+public partial class CommandTypes
+{
+	public class CSk_ : ISerializable
+	{
+		public const int DataSize = 16;
+
+        public UInt32 VibrationMode;
+
+        public UInt32[] UNUSED_UINT32 = new UInt32[4];
+
+		public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
+		{
+            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
+            Trace.Assert(this.UNUSED_UINT32[0] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[0]}) in reserve variable.");
+
+			rw.RwUInt32(ref this.VibrationMode);
+
+            for (int i=1; i<this.UNUSED_UINT32.Length; i++)
+            {
+                rw.RwUInt32(ref this.UNUSED_UINT32[i]);
+                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
+            }
+		}
+	}
+}
+

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/MAAB.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/MAAB.cs
@@ -12,8 +12,7 @@ public partial class CommandTypes
     {
         public const int DataSize = 80;
 
-        private UInt32 _bitfield;
-        public Bitfield Flags = new Bitfield(0);
+        public Bitfield32 Flags = new Bitfield32();
 
         public Int32 ChildObjectId;
 
@@ -24,11 +23,7 @@ public partial class CommandTypes
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
-            if (rw.IsParselike())
-                this._bitfield = this.Flags.Compose();
-            rw.RwUInt32(ref this._bitfield);
-            this.Flags = new Bitfield(this._bitfield);
-
+            rw.RwObj(ref this.Flags);
             rw.RwInt32(ref this.ChildObjectId);
 
             rw.RwUInt32(ref this.UNUSED_UINT32[0]);

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/MAA_.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/MAA_.cs
@@ -15,8 +15,7 @@ public partial class CommandTypes
 
         public AnimationStruct AddAnimation = new AnimationStruct(loopBool:0, weight:1.0F);
 
-        private UInt32 _bitfield;
-        public Bitfield Flags = new Bitfield(0);
+        public Bitfield32 Flags = new Bitfield32();
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
@@ -29,10 +28,7 @@ public partial class CommandTypes
             rw.RwFloat32(ref this.AddAnimation.PlaybackSpeed);
             rw.RwUInt32(ref this.AddAnimation.StartingFrame);
 
-            if (rw.IsParselike())
-                this._bitfield = this.Flags.Compose();
-            rw.RwUInt32(ref this._bitfield);
-            this.Flags = new Bitfield(this._bitfield);
+            rw.RwObj(ref this.Flags);
         }
     }
 }

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/MAB_.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/MAB_.cs
@@ -20,8 +20,7 @@ public partial class CommandTypes
         public UInt16 SecondAnimationUnkFrames;
         public UInt16 SecondAnimationInterpolatedFrames;
 
-        private UInt32 _bitfield;
-        public Bitfield Flags = new Bitfield(0);
+        public Bitfield32 Flags = new Bitfield32();
 
         public UInt32 StartWaitingFrames;
 
@@ -53,10 +52,7 @@ public partial class CommandTypes
             rw.RwUInt32(ref this.SecondAnimation.LoopBool);
             rw.RwFloat32(ref this.SecondAnimation.PlaybackSpeed);
 
-            if (rw.IsParselike())
-                this._bitfield = this.Flags.Compose();
-            rw.RwUInt32(ref this._bitfield);
-            this.Flags = new Bitfield(this._bitfield);
+            rw.RwObj(ref this.Flags);
 
             rw.RwUInt32(ref this.FirstAnimation.StartingFrame);
             rw.RwUInt32(ref this.FirstAnimation.EndingFrame);

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/MAI_.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/MAI_.cs
@@ -13,8 +13,7 @@ public partial class CommandTypes
     {
         public const int DataSize = 256;
 
-        private UInt32[] _bitfield = new UInt32[] {5, 4, 4, 4, 4, 4, 4, 4, 4, 4};
-        public Bitfield[] IdleAnimationBitfields = Enumerable.Range(0, 10).Select(i => new Bitfield((uint)((i == 0) ? 5 : 4))).ToArray();
+        public Bitfield32[] IdleAnimationBitfields = Enumerable.Range(0, 10).Select(i => new Bitfield32((uint)((i == 0) ? 5 : 4))).ToArray();
 
         public AnimationStruct[] IdleAnimations = Enumerable.Range(0, 10).Select(_ => new AnimationStruct(endingFrame:0)).ToArray();
 
@@ -26,10 +25,7 @@ public partial class CommandTypes
 
             for (int i=0; i<10; i++)
             {
-                if (rw.IsParselike())
-                    this._bitfield[i] = this.IdleAnimationBitfields[i].Compose();
-                rw.RwUInt32(ref this._bitfield[i]);
-                this.IdleAnimationBitfields[i] = new Bitfield(this._bitfield[i]);
+                rw.RwObj(ref this.IdleAnimationBitfields[i]);
                 rw.RwUInt32(ref this.IdleAnimations[i].Index);
                 rw.RwUInt32(ref this.IdleAnimations[i].StartingFrame);
                 rw.RwUInt32(ref this.IdleAnimations[i].EndingFrame);

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/MAt_.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/MAt_.cs
@@ -12,8 +12,7 @@ public partial class CommandTypes
     {
         public const int DataSize = 48;
 
-        private UInt32 _bitfield;
-        public Bitfield Flags = new Bitfield(0);
+        public Bitfield32 Flags = new Bitfield32();
 
         public UInt32 HelperId;
         public Int32 ChildObjectId;
@@ -25,10 +24,7 @@ public partial class CommandTypes
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
-            if (rw.IsParselike())
-                this._bitfield = this.Flags.Compose();
-            rw.RwUInt32(ref this._bitfield);
-            this.Flags = new Bitfield(this._bitfield);
+            rw.RwObj(ref this.Flags);
 
             rw.RwUInt32(ref this.HelperId);
             rw.RwInt32(ref this.ChildObjectId);

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/MCSd.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/MCSd.cs
@@ -12,8 +12,7 @@ public partial class CommandTypes
     {
         public const int DataSize = 32;
 
-        private UInt32 _bitfield;
-        public Bitfield Flags = new Bitfield(0);
+        public Bitfield32 Flags = new Bitfield32();
 
         public UInt32 InnerCircleRGBA = 0x00000080;
         public UInt32 OuterCircleRGBA = 0x00000060;
@@ -25,10 +24,7 @@ public partial class CommandTypes
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
-            if (rw.IsParselike())
-                this._bitfield = this.Flags.Compose();
-            rw.RwUInt32(ref this._bitfield);
-            this.Flags = new Bitfield(this._bitfield);
+            rw.RwObj(ref this.Flags);
 
             rw.RwUInt32(ref this.InnerCircleRGBA);
             rw.RwUInt32(ref this.OuterCircleRGBA);

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/MDt_.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/MDt_.cs
@@ -12,8 +12,7 @@ public partial class CommandTypes
     {
         public const int DataSize = 48;
 
-        private UInt32 _bitfield;
-        public Bitfield Flags = new Bitfield(3);
+        public Bitfield32 Flags = new Bitfield32(3);
 
         public UInt32 HelperId;
         public Int32 ChildObjectId;
@@ -25,10 +24,7 @@ public partial class CommandTypes
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
-            if (rw.IsParselike())
-                this._bitfield = this.Flags.Compose();
-            rw.RwUInt32(ref this._bitfield);
-            this.Flags = new Bitfield(this._bitfield);
+            rw.RwObj(ref this.Flags);
 
             rw.RwUInt32(ref this.HelperId);
             rw.RwInt32(ref this.ChildObjectId);

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/MFts.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/MFts.cs
@@ -12,8 +12,7 @@ public partial class CommandTypes
     {
         public const int DataSize = 16;
 
-        private UInt32 _bitfield;
-        public Bitfield Flags = new Bitfield(0);
+        public Bitfield32 Flags = new Bitfield32();
 
         public float Strength;
 
@@ -21,10 +20,7 @@ public partial class CommandTypes
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
-            if (rw.IsParselike())
-                this._bitfield = this.Flags.Compose();
-            rw.RwUInt32(ref this._bitfield);
-            this.Flags = new Bitfield(this._bitfield);
+            rw.RwObj(ref this.Flags);
 
             rw.RwFloat32(ref this.Strength);
 

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/MLa_.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/MLa_.cs
@@ -13,9 +13,7 @@ public partial class CommandTypes
         public const int DataSize = 32;
 
         public UInt16 ResetEyeWhenMoving;
-
-        private UInt16 _bitfield;
-        public Bitfield Flags = new Bitfield(0);
+        public Bitfield16 Flags = new Bitfield16();
 
         public UInt16 MotionType;
         public UInt16 SpeedType = 2;
@@ -28,11 +26,7 @@ public partial class CommandTypes
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
             rw.RwUInt16(ref this.ResetEyeWhenMoving);
-
-            if (rw.IsParselike())
-                this._bitfield = (UInt16)this.Flags.Compose();
-            rw.RwUInt16(ref this._bitfield);
-            this.Flags = new Bitfield((UInt32)this._bitfield);
+            rw.RwObj(ref this.Flags);
 
             rw.RwUInt16(ref this.MotionType);
             rw.RwUInt16(ref this.SpeedType);

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/MMD_.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/MMD_.cs
@@ -16,8 +16,7 @@ public partial class CommandTypes
         public UInt32 NumControlGroups = 1;
         public float[,] Targets = new float[24,3];
 
-        private UInt32 _bitfield;
-        public Bitfield Flags = new Bitfield(0);
+        public Bitfield32 Flags = new Bitfield32();
 
         public float MovementSpeed = 1.0F;
         public UInt32 UNK;
@@ -44,14 +43,9 @@ public partial class CommandTypes
                     for (int j=0; j<3; j++)
                         rw.RwFloat32(ref this.Targets[i,j]);
 
-            if (rw.IsParselike())
-                this._bitfield = this.Flags.Compose();
-            rw.RwUInt32(ref this._bitfield);
-            this.Flags = new Bitfield(this._bitfield);
-
+            rw.RwObj(ref this.Flags);
             rw.RwFloat32(ref this.MovementSpeed);
             rw.RwUInt32(ref this.UNK);
-
             rw.RwUInt8(ref this.StartSpeedType);
             rw.RwUInt8(ref this.FinalSpeedType);
 

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/MRot.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/MRot.cs
@@ -12,9 +12,7 @@ public partial class CommandTypes
     {
         public const int DataSize = 96;
 
-        private UInt32 _bitfield;
-        public Bitfield Flags = new Bitfield(1);
-
+        public Bitfield32 Flags = new Bitfield32(1);
         public float[] Rotation = new float[3];
         public UInt32  InterpolationType;
         public UInt32  UNK;
@@ -26,12 +24,8 @@ public partial class CommandTypes
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
-            if (rw.IsParselike())
-                this._bitfield = this.Flags.Compose();
-            rw.RwUInt32(ref this._bitfield);
-            this.Flags = new Bitfield(this._bitfield);
+            rw.RwObj(ref this.Flags);
             rw.RwFloat32s(ref this.Rotation, 3);
-
             rw.RwUInt32(ref this.InterpolationType);
             rw.RwUInt32(ref this.UNK);
 

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/MSD_.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/MSD_.cs
@@ -17,8 +17,7 @@ public partial class CommandTypes
 
         public AnimationStruct WaitingAnimation = new AnimationStruct(loopBool:1);
 
-        public UInt32 _bitfield;
-        public Bitfield Flags = new Bitfield(0);
+        public Bitfield32 Flags = new Bitfield32();
 
         public UInt32[] UNUSED_UINT32 = new UInt32[4];
 
@@ -34,10 +33,7 @@ public partial class CommandTypes
             rw.RwUInt32(ref this.WaitingAnimation.LoopBool);
             rw.RwFloat32(ref this.WaitingAnimation.PlaybackSpeed);
 
-            if (rw.IsParselike())
-                this._bitfield = this.Flags.Compose();
-            rw.RwUInt32(ref this._bitfield);
-            this.Flags = new Bitfield(this._bitfield);
+            rw.RwObj(ref this.Flags);
 
             rw.RwUInt32(ref this.WaitingAnimation.StartingFrame);
 

--- a/src/lib/FileIO/Formats/EVT/EVT.cs
+++ b/src/lib/FileIO/Formats/EVT/EVT.cs
@@ -26,8 +26,7 @@ public class EVT : ISerializable
     public Int32 FileSize;
     public Int32 FileHeaderSize;
 
-    private UInt32 _bitfield;
-    public Bitfield Flags = new Bitfield(0);
+    public Bitfield32 Flags = new Bitfield32();
 
     public Int32 FrameCount;
     public byte FrameRate = 30;
@@ -82,12 +81,7 @@ public class EVT : ISerializable
         Trace.Assert(this.DUMMY_INT16[0] == 0);
         rw.RwInt32(ref this.FileSize);
         rw.RwInt32(ref this.FileHeaderSize);
-
-        if (rw.IsParselike())
-            this._bitfield = this.Flags.Compose();
-        rw.RwUInt32(ref this._bitfield);
-        this.Flags = new Bitfield(this._bitfield);
-
+        rw.RwObj(ref this.Flags);
         rw.RwInt32(ref this.FrameCount);
         rw.RwUInt8(ref this.FrameRate);
         rw.RwUInt8(ref this.InitScriptIndex);
@@ -356,22 +350,21 @@ public class EVT : ISerializable
 
 public class SerialObject : ISerializable
 {
-    public Int32  Id;
-    public Int32  Type;
-    public Int32  ResourceCategory = 1;
-    public Int32  ResourceUniqueId;
-    public Int32  ResourceMajorId;
-    public Int16  ResourceSubId;
-    public Int16  ResourceMinorId;
+    public Int32 Id;
+    public Int32 Type;
+    public Int32 ResourceCategory = 1;
+    public Int32 ResourceUniqueId;
+    public Int32 ResourceMajorId;
+    public Int16 ResourceSubId;
+    public Int16 ResourceMinorId;
 
-    private UInt32 _bitfield;
-    public Bitfield Flags = new Bitfield(0);
+    public Bitfield32 Flags = new Bitfield32();
 
-    public Int32  BaseMotionNo     = -1;
-    public Int32  ExtBaseMotionNo  = -1;
-    public Int32  ExtAddMotionNo   = -1;
-    public Int32  UnkBool;
-    public Int32  Reserve2C;
+    public Int32 BaseMotionNo     = -1;
+    public Int32 ExtBaseMotionNo  = -1;
+    public Int32 ExtAddMotionNo   = -1;
+    public Int32 UnkBool;
+    public Int32 Reserve2C;
 
     public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
     {
@@ -382,12 +375,7 @@ public class SerialObject : ISerializable
         rw.RwInt32(ref this.ResourceMajorId);
         rw.RwInt16(ref this.ResourceSubId);
         rw.RwInt16(ref this.ResourceMinorId);
-
-        if (rw.IsParselike())
-            this._bitfield = this.Flags.Compose();
-        rw.RwUInt32(ref this._bitfield);
-        this.Flags = new Bitfield(this._bitfield);
-
+        rw.RwObj(ref this.Flags);
         rw.RwInt32(ref this.BaseMotionNo);
         rw.RwInt32(ref this.ExtBaseMotionNo);
         rw.RwInt32(ref this.ExtAddMotionNo);


### PR DESCRIPTION
All camera-related commands are now fully parsed and editable in the UI. This includes:

- CAA_
- CAR_
- CClp
- CMC_
- CMCn
- CMD_
- CQuk
- CSA_
- CSD_
- CSDD
- CSEc
- CShk
- CSk_

Some of these are only attested in very old EVTs, or even only by EVTs created in the beta P5 editor, so they may need to be revisited re: whether they can be added to new EVTs if they're just going to break as a result....

## Other additions:
- `Bitfield` classes now make these variables much less verbose to read/write/update
- `InterpolationParameters` classes make such repeating/stock blocks quicker to add to the UI

## For a future PR:
- Make commands more sensitive to active game and/or EVT version, if indeed some command versions are incompatible with some game/EVT versions (a fact which seems likely but is currently untested)
- Consolidate some common enum-likes (like `BlurTypes` and `MessageCoordinateTypes` into a shared location 