### PR TITLE
Fix camera asset commands + make command frame settings editable

### DIFF
--- a/src/gui/EditorWindow/TimelinePanel/CommandViewModels/CAA_.cs
+++ b/src/gui/EditorWindow/TimelinePanel/CommandViewModels/CAA_.cs
@@ -7,8 +7,7 @@ public class CAA_ : Generic
         this.LongName = "Camera: Additive Animation";
 
         // animation source
-        // this is technically 0-999, and also camera assets only, so... TODO either way
-        this.AssetID = new IntSelectionField("Asset ID", this.Editable, this.CommandData.AssetId, config.EventManager.AssetIDs);
+        this.AssetID = new IntSelectionField("Asset ID", this.Editable, this.CommandData.AssetId, config.EventManager.AssetIDsOfType(0x00000007));
         this.AnimationID = new NumEntryField("Animation ID", this.Editable, this.CommandData.AnimationId, 0, 59, 1);
         this.PlaybackSpeed = new NumEntryField("Playback Speed", this.Editable, this.CommandData.PlaybackSpeed, 0, 10, 0.1);
 

--- a/src/gui/EditorWindow/TimelinePanel/CommandViewModels/CSA_.cs
+++ b/src/gui/EditorWindow/TimelinePanel/CommandViewModels/CSA_.cs
@@ -11,8 +11,7 @@ public class CSA_ : Generic
         this.LongName = "Camera: Base Animation";
 
         // animation source
-        // this is technically 0-999, and also camera assets only, so... TODO either way
-        this.AssetID = new IntSelectionField("Asset ID", this.Editable, this.CommandData.AssetId, config.EventManager.AssetIDs);
+        this.AssetID = new IntSelectionField("Asset ID", this.Editable, this.CommandData.AssetId, config.EventManager.AssetIDsOfType(0x00000007));
         this.AnimationID = new NumEntryField("Animation ID", this.Editable, this.CommandData.AnimationId, 0, 59, 1);
         this.PlaybackSpeed = new NumEntryField("Playback Speed", this.Editable, this.CommandData.PlaybackSpeed, 0, 10, 0.1);
         this.StartingFrame = new NumEntryField("Starting Frame", this.Editable, this.CommandData.StartingFrame, 0, 99999, 1);

--- a/src/gui/EditorWindow/TimelinePanel/CommandViewModels/CSEc.cs
+++ b/src/gui/EditorWindow/TimelinePanel/CommandViewModels/CSEc.cs
@@ -11,7 +11,7 @@ public class CSEc : Generic
     {
         this.LongName = "Camera: Load From Asset";
 
-        this.AssetID = new IntSelectionField("Asset ID", this.Editable, this.Command.ObjectId, config.EventManager.AssetIDs);
+        this.AssetID = new IntSelectionField("Asset ID", this.Editable, this.CommandData.AssetId, config.EventManager.AssetIDsOfType(0x00000009));
         this.EnableEditing = new BoolChoiceField("Enable Editing?", this.Editable, this.CommandData.Flags[0]);
 
         // message

--- a/src/gui/EditorWindow/TimelinePanel/CommandViewModels/Generic.cs
+++ b/src/gui/EditorWindow/TimelinePanel/CommandViewModels/Generic.cs
@@ -39,10 +39,16 @@ public class Basics : ReactiveObject
         this.Command = command;
         this.Editable = !config.ReadOnly;
 
+        this.WaitOnCommand = new BoolChoiceField("Wait while frame is stopped?", this.Editable, this.Command.Flags[1]);
+        // i don't feel like making this reactive lol that's annoying, woe readonly be upon you
+        this.StartingFrame = new NumEntryField("Starting Frame", false, this.Command.FrameStart, 0, 999999, 1);
+        this.FrameCount = new NumEntryField("Frame Duration", this.Editable, this.Command.FrameDuration, 0, 999999, 1);
+
+        this.ForceSkipCommand = new BoolChoiceField("Force-skip command?", this.Editable, this.Command.Flags[0]);
         this.ConditionalType = new StringSelectionField("Conditional Type", this.Editable, this.ConditionalTypes.Backward[this.Command.ConditionalType], this.ConditionalTypes.Keys);
-        this.ConditionalIndex = new NumEntryField("Conditional Index", this.Editable, (int)this.Command.ConditionalIndex, 0, null, 1);
+        this.ConditionalIndex = new NumEntryField("Conditional Index", this.Editable, this.Command.ConditionalIndex, 0, null, 1);
         this.ComparisonType = new StringSelectionField("Comparison Type", this.Editable, this.ComparisonTypes.Backward[this.Command.ConditionalComparisonType], this.ComparisonTypes.Keys);
-        this.ConditionalValue = new NumEntryField("Conditional Value", this.Editable, (int)this.Command.ConditionalValue, null, null, 1);
+        this.ConditionalValue = new NumEntryField("Conditional Value", this.Editable, this.Command.ConditionalValue, null, null, 1);
 
         this.WhenAnyValue(x => x.ConditionalType.Choice).Subscribe(x =>
         {
@@ -59,6 +65,11 @@ public class Basics : ReactiveObject
         });
     }
 
+    public BoolChoiceField      WaitOnCommand { get; set; }
+    public NumEntryField        StartingFrame { get; set; }
+    public NumEntryField        FrameCount    { get; set; }
+
+    public BoolChoiceField      ForceSkipCommand { get; set; }
     public StringSelectionField ConditionalType  { get; set; }
     public NumEntryField        ConditionalIndex { get; set; }
     public StringSelectionField ComparisonType   { get; set; }
@@ -69,6 +80,13 @@ public class Basics : ReactiveObject
 
     public void SaveChanges()
     {
+
+        this.Command.Flags[0] = this.ForceSkipCommand.Value;
+        this.Command.Flags[1] = this.WaitOnCommand.Value;
+
+        this.Command.FrameStart    = (int)this.StartingFrame.Value;
+        this.Command.FrameDuration = (int)this.FrameCount.Value;
+
         this.Command.ConditionalType           = this.ConditionalTypes.Forward[this.ConditionalType.Choice];
         this.Command.ConditionalIndex          = (uint)this.ConditionalIndex.Value;
         this.Command.ConditionalValue          = (int)this.ConditionalValue.Value;

--- a/src/gui/EditorWindow/TimelinePanel/TimelinePanel.axaml
+++ b/src/gui/EditorWindow/TimelinePanel/TimelinePanel.axaml
@@ -160,14 +160,24 @@
 
     <DataTemplate DataType="{x:Type cmds:Basics}">
       <StackPanel Classes="form">
-        <Expander Header="Conditions" IsExpanded="{c:Binding 'ConditionalType.Choice != \'Always Run\'', Mode=OneTime}">
+        <Expander Header="Conditions" IsExpanded="{c:Binding 'ForceSkipCommand.Value || ConditionalType.Choice != \'Always Run\'', Mode=OneTime}">
           <StackPanel Classes="form">
-            <ContentControl Content="{Binding ConditionalType}"/>
-            <StackPanel Classes="form" IsVisible="{c:Binding '(ConditionalType.Choice != \'Always Run\') and (ConditionalType.Choice != \'Never Run\')', Mode=OneWay}">
-              <ContentControl Content="{Binding ConditionalIndex}"/>
-              <ContentControl Content="{Binding ComparisonType}"/>
-              <ContentControl Content="{Binding ConditionalValue}"/>
+            <ContentControl Content="{Binding ForceSkipCommand}"/>
+            <StackPanel Classes="form" IsVisible="{Binding !ForceSkipCommand.Value}">
+              <ContentControl Content="{Binding ConditionalType}"/>
+              <StackPanel Classes="form" IsVisible="{c:Binding '(ConditionalType.Choice != \'Always Run\') and (ConditionalType.Choice != \'Never Run\')', Mode=OneWay}">
+                <ContentControl Content="{Binding ConditionalIndex}"/>
+                <ContentControl Content="{Binding ComparisonType}"/>
+                <ContentControl Content="{Binding ConditionalValue}"/>
+              </StackPanel>
             </StackPanel>
+          </StackPanel>
+        </Expander>
+        <Expander Header="Frame Settings" IsExpanded="false">
+          <StackPanel Classes="form">
+            <ContentControl Content="{Binding WaitOnCommand}"/>
+            <ContentControl Content="{Binding StartingFrame}"/>
+            <ContentControl Content="{Binding FrameCount}"/>
           </StackPanel>
         </Expander>
         <Separator Classes="formsubtitle"/>

--- a/src/lib/EventManager.cs
+++ b/src/lib/EventManager.cs
@@ -155,6 +155,15 @@ public class EventManager
         }
     }
 
+    public List<int> AssetIDsOfType(int type)
+    {
+        List<int> ids = new List<int>();
+        foreach (SerialObject obj in this.SerialEvent.Objects)
+            if (obj.Type == type)
+                ids.Add(obj.Id);
+        return ids;
+    }
+
     public List<string> GetAssetPaths(int assetId, List<string> cpkList, string targetdir)
     {
         if (!(this.ObjectsById.ContainsKey(assetId)))

--- a/src/lib/FileIO/Formats/EVT/EVT.cs
+++ b/src/lib/FileIO/Formats/EVT/EVT.cs
@@ -392,7 +392,7 @@ public class SerialCommand : ISerializable
     public Int16  CommandVersion;
     public Int16  CommandType;
     public Int32  ObjectId;
-    public Int32  Flags;
+    public Bitfield32 Flags = new Bitfield32();
     public Int32  FrameStart;
     public Int32  FrameDuration = 1;
     public Int32  DataOffset;
@@ -408,7 +408,7 @@ public class SerialCommand : ISerializable
         rw.RwInt16(ref this.CommandVersion);
         rw.RwInt16(ref this.CommandType);
         rw.RwInt32(ref this.ObjectId);
-        rw.RwInt32(ref this.Flags);
+        rw.RwObj(ref this.Flags);
         rw.RwInt32(ref this.FrameStart);
         rw.RwInt32(ref this.FrameDuration);
         rw.RwInt32(ref this.DataOffset);


### PR DESCRIPTION
- Fixes for `CAA_`, `CSA_`, and `CSEc`... coming from handling the asset ID part correctly.
- Fixes for `CQuk` and any number of commands that rely on longer frame durations to work... coming from command duration actually being editable now, lol.