### PR TITLE
Implement all field-related commands

### DIFF
--- a/src/gui/EditorWindow/TimelinePanel/CommandViewModels/FAA_.cs
+++ b/src/gui/EditorWindow/TimelinePanel/CommandViewModels/FAA_.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+
+namespace EVTUI.ViewModels.TimelineCommands;
+
+public class FAA_ : Generic
+{
+    public FAA_(DataManager config, SerialCommand command, object commandData) : base(config, command, commandData)
+    {
+        this.LongName = "Field: Additive Animation";
+        this.AssetID = new IntSelectionField("Asset ID", this.Editable, this.Command.ObjectId, config.EventManager.AssetIDs);
+
+        this.ObjectIndex = new NumEntryField("Field Object Index", this.Editable, this.CommandData.ObjectIndex, 0, 65535, 1);
+        this.FirstAnimation = new AnimationWidget(config, this.AssetID, this.CommandData.FirstAnimation, this.CommandData.Flags, $"First Animation", frameBlendingInd:1, trackNum:0);
+        this.SecondAnimation = new AnimationWidget(config, this.AssetID, this.CommandData.SecondAnimation, this.CommandData.Flags, $"Second Animation", enabledInd:0, frameBlendingInd:2, enabledFlip:true, trackNum:0);
+        this.DebugFrameForward = new BoolChoiceField("Frame Forward", this.Editable, this.CommandData.Flags[31]);
+
+    }
+
+    public IntSelectionField AssetID           { get; set; }
+
+    public NumEntryField ObjectIndex       { get; set; }
+    public AnimationWidget   FirstAnimation    { get; set; }
+    public AnimationWidget   SecondAnimation   { get; set; }
+
+    public BoolChoiceField   DebugFrameForward { get; set; }
+
+    public new void SaveChanges()
+    {
+        base.SaveChanges();
+        this.Command.ObjectId = this.AssetID.Choice;
+
+        this.CommandData.ObjectIndex = (uint)this.ObjectIndex.Value;
+        this.FirstAnimation.SaveChanges();
+        this.SecondAnimation.SaveChanges();
+        this.CommandData.Flags[31] = this.DebugFrameForward.Value;
+    }
+}

--- a/src/gui/EditorWindow/TimelinePanel/CommandViewModels/FAB_.cs
+++ b/src/gui/EditorWindow/TimelinePanel/CommandViewModels/FAB_.cs
@@ -1,15 +1,15 @@
 namespace EVTUI.ViewModels.TimelineCommands;
 
-public class FAA_ : Generic
+public class FAB_ : Generic
 {
-    public FAA_(DataManager config, SerialCommand command, object commandData) : base(config, command, commandData)
+    public FAB_(DataManager config, SerialCommand command, object commandData) : base(config, command, commandData)
     {
-        this.LongName = "Field: Additive Animation";
+        this.LongName = "Field: Base Animation";
         this.AssetID = new IntSelectionField("Asset ID", this.Editable, this.Command.ObjectId, config.EventManager.AssetIDsOfType(0x00000003));
 
         this.ObjectIndex = new NumEntryField("Field Object Index", this.Editable, this.CommandData.ObjectIndex, 0, 65535, 1);
-        this.FirstAnimation = new AnimationWidget(config, this.AssetID, this.CommandData.FirstAnimation, this.CommandData.Flags, $"First Animation", frameBlendingInd:1, trackNum:0);
-        this.SecondAnimation = new AnimationWidget(config, this.AssetID, this.CommandData.SecondAnimation, this.CommandData.Flags, $"Second Animation", enabledInd:0, frameBlendingInd:2, enabledFlip:true, trackNum:0);
+        this.FirstAnimation = new AnimationWidget(config, this.AssetID, this.CommandData.FirstAnimation, this.CommandData.Flags, $"First Animation", frameBlendingInd:1);
+        this.SecondAnimation = new AnimationWidget(config, this.AssetID, this.CommandData.SecondAnimation, this.CommandData.Flags, $"Second Animation", enabledInd:0, frameBlendingInd:2, enabledFlip:true);
         this.DebugFrameForward = new BoolChoiceField("Frame Forward", this.Editable, this.CommandData.Flags[31]);
 
     }

--- a/src/gui/EditorWindow/TimelinePanel/CommandViewModels/FDFl.cs
+++ b/src/gui/EditorWindow/TimelinePanel/CommandViewModels/FDFl.cs
@@ -1,0 +1,22 @@
+namespace EVTUI.ViewModels.TimelineCommands;
+
+public class FDFl : Generic
+{
+    public FDFl(DataManager config, SerialCommand command, object commandData) : base(config, command, commandData)
+    {
+        this.LongName = "Field: ???";
+        this.AssetID = new IntSelectionField("Asset ID", this.Editable, this.Command.ObjectId, config.EventManager.AssetIDsOfType(0x00000003));
+        this.Unk = new NumEntryField("Unknown", this.Editable, this.CommandData.Unk1, 0, null, 1);
+
+    }
+
+    public IntSelectionField AssetID { get; set; }
+    public NumEntryField     Unk     { get; set; }
+
+    public new void SaveChanges()
+    {
+        base.SaveChanges();
+        this.Command.ObjectId = this.AssetID.Choice;
+        this.CommandData.Unk1 = (uint)this.Unk.Value;
+    }
+}

--- a/src/gui/EditorWindow/TimelinePanel/CommandViewModels/FGFl.cs
+++ b/src/gui/EditorWindow/TimelinePanel/CommandViewModels/FGFl.cs
@@ -1,0 +1,22 @@
+namespace EVTUI.ViewModels.TimelineCommands;
+
+public class FGFl : Generic
+{
+    public FGFl(DataManager config, SerialCommand command, object commandData) : base(config, command, commandData)
+    {
+        this.LongName = "Field: ???";
+        this.AssetID = new IntSelectionField("Asset ID", this.Editable, this.Command.ObjectId, config.EventManager.AssetIDsOfType(0x00000003));
+        this.Unk = new NumEntryField("Unknown", this.Editable, this.CommandData.Unk, 0, 2, 1);
+
+    }
+
+    public IntSelectionField AssetID { get; set; }
+    public NumEntryField     Unk     { get; set; }
+
+    public new void SaveChanges()
+    {
+        base.SaveChanges();
+        this.Command.ObjectId = this.AssetID.Choice;
+        this.CommandData.Unk = (uint)this.Unk.Value;
+    }
+}

--- a/src/gui/EditorWindow/TimelinePanel/CommandViewModels/FOD_.cs
+++ b/src/gui/EditorWindow/TimelinePanel/CommandViewModels/FOD_.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+
+using static EVTUI.ViewModels.FieldUtils;
+
+namespace EVTUI.ViewModels.TimelineCommands;
+
+public class FOD_ : Generic
+{
+    public FOD_(DataManager config, SerialCommand command, object commandData) : base(config, command, commandData)
+    {
+        this.LongName = "Field: Object Placement";
+        this.AssetID = new IntSelectionField("Asset ID", this.Editable, this.Command.ObjectId, config.EventManager.AssetIDsOfType(0x00000003));
+
+        this.ActionType = new StringSelectionField("Mode", this.Editable, this.ActionTypes.Backward[this.CommandData.EnableFieldObject], this.ActionTypes.Keys);
+        this.ObjectIndex = new NumEntryField("Field Object Index", this.Editable, this.CommandData.ObjectIndex, 0, 65535, 1);
+
+    }
+
+    public IntSelectionField AssetID { get; set; }
+
+    public StringSelectionField ActionType  { get; set; }
+    public NumEntryField        ObjectIndex { get; set; }
+
+    public new void SaveChanges()
+    {
+        base.SaveChanges();
+        this.Command.ObjectId = this.AssetID.Choice;
+
+        this.CommandData.EnableFieldObject = this.ActionTypes.Forward[this.ActionType.Choice];
+        this.CommandData.ObjectIndex       = (uint)this.ObjectIndex.Value;
+    }
+
+    public BiDict<string, uint> ActionTypes = new BiDict<string, uint>
+    (
+        new Dictionary<string, uint>
+        {
+            {"Hide", 0},
+            {"Show", 1},
+        }
+    );
+
+}

--- a/src/gui/EditorWindow/TimelinePanel/CommandViewModels/FS__.cs
+++ b/src/gui/EditorWindow/TimelinePanel/CommandViewModels/FS__.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+
+using static EVTUI.ViewModels.FieldUtils;
+
+namespace EVTUI.ViewModels.TimelineCommands;
+
+public class FS__ : Generic
+{
+    public FS__(DataManager config, SerialCommand command, object commandData) : base(config, command, commandData)
+    {
+        this.LongName = "Field: Placement";
+        this.AssetID = new IntSelectionField("Asset ID", this.Editable, this.Command.ObjectId, config.EventManager.AssetIDsOfType(0x00000003));
+
+        // position
+        this.X = new NumRangeField("X", this.Editable, this.CommandData.Coordinates[0], -99999, 99999, 1);
+        this.Y = new NumRangeField("Y", this.Editable, this.CommandData.Coordinates[1], -99999, 99999, 1);
+        this.Z = new NumRangeField("Z", this.Editable, this.CommandData.Coordinates[2], -99999, 99999, 1);
+
+        // rotation
+        // i may have yaw and pitch switched around here, dunno
+        this.Yaw = new NumRangeField("Yaw", this.Editable, this.CommandData.Rotation[0], -180, 180, 1);
+        this.Pitch = new NumRangeField("Pitch", this.Editable, this.CommandData.Rotation[1], -180, 180, 1);
+        this.Roll = new NumRangeField("Roll", this.Editable, this.CommandData.Rotation[2], -180, 180, 1);
+
+        // unknown
+        this.UnkBool = new BoolChoiceField("Unknown #1", this.Editable, this.CommandData.UnkBool != 0);
+        this.UnkFloat = new NumEntryField("Unknown #2", this.Editable, this.CommandData.UnkFloat, -9999, 9999, 1);
+    }
+
+    public IntSelectionField AssetID { get; set; }
+
+    // position
+    public NumRangeField X { get; set; }
+    public NumRangeField Y { get; set; }
+    public NumRangeField Z { get; set; }
+
+    // rotation
+    public NumRangeField Yaw   { get; set; }
+    public NumRangeField Pitch { get; set; }
+    public NumRangeField Roll  { get; set; }
+
+    // unknown
+    public BoolChoiceField UnkBool  { get; set; }
+    public NumEntryField   UnkFloat { get; set; }
+
+    public new void SaveChanges()
+    {
+        base.SaveChanges();
+        this.Command.ObjectId = this.AssetID.Choice;
+
+        this.CommandData.UnkBool = Convert.ToUInt32(this.UnkBool.Value);
+
+        this.CommandData.Coordinates[0] = (float)this.X.Value;
+        this.CommandData.Coordinates[1] = (float)this.Y.Value;
+        this.CommandData.Coordinates[2] = (float)this.Z.Value;
+
+        this.CommandData.Rotation[0] = (float)this.Yaw.Value;
+        this.CommandData.Rotation[1] = (float)this.Pitch.Value;
+        this.CommandData.Rotation[2] = (float)this.Roll.Value;
+
+        this.CommandData.UnkFloat = (float)this.UnkFloat.Value;
+    }
+
+    public BiDict<string, uint> ActionTypes = new BiDict<string, uint>
+    (
+        new Dictionary<string, uint>
+        {
+            {"Hide", 0},
+            {"Show", 1},
+        }
+    );
+
+}

--- a/src/gui/EditorWindow/TimelinePanel/TimelinePanel.axaml
+++ b/src/gui/EditorWindow/TimelinePanel/TimelinePanel.axaml
@@ -518,6 +518,23 @@
       </StackPanel>
     </DataTemplate>
 
+    <DataTemplate DataType="{x:Type cmds:FAA_}">
+      <StackPanel Classes="form">
+        <TextBlock Classes="formtitle" Text="{Binding LongName}"/>
+        <Separator Classes="formtitle"/>
+        <ContentControl Content="{Binding Basics}"/>
+        <ContentControl Content="{Binding AssetID}"/>
+        <ContentControl Content="{Binding ObjectIndex}"/>
+        <ContentControl Content="{Binding FirstAnimation}"/>
+        <ContentControl Content="{Binding SecondAnimation}"/>
+        <Expander Header="Debug">
+          <StackPanel Classes="form">
+            <ContentControl Content="{Binding DebugFrameForward}"/>
+          </StackPanel>
+        </Expander>
+      </StackPanel>
+    </DataTemplate>
+
     <DataTemplate DataType="{x:Type cmds:FrJ_}">
       <StackPanel Classes="form">
         <TextBlock Classes="formtitle" Text="{Binding LongName}"/>

--- a/src/gui/EditorWindow/TimelinePanel/TimelinePanel.axaml
+++ b/src/gui/EditorWindow/TimelinePanel/TimelinePanel.axaml
@@ -535,6 +535,83 @@
       </StackPanel>
     </DataTemplate>
 
+    <DataTemplate DataType="{x:Type cmds:FAB_}">
+      <StackPanel Classes="form">
+        <TextBlock Classes="formtitle" Text="{Binding LongName}"/>
+        <Separator Classes="formtitle"/>
+        <ContentControl Content="{Binding Basics}"/>
+        <ContentControl Content="{Binding AssetID}"/>
+        <ContentControl Content="{Binding ObjectIndex}"/>
+        <ContentControl Content="{Binding FirstAnimation}"/>
+        <ContentControl Content="{Binding SecondAnimation}"/>
+        <Expander Header="Debug">
+          <StackPanel Classes="form">
+            <ContentControl Content="{Binding DebugFrameForward}"/>
+          </StackPanel>
+        </Expander>
+      </StackPanel>
+    </DataTemplate>
+
+    <DataTemplate DataType="{x:Type cmds:FOD_}">
+      <StackPanel Classes="form">
+        <TextBlock Classes="formtitle" Text="{Binding LongName}"/>
+        <Separator Classes="formtitle"/>
+        <ContentControl Content="{Binding Basics}"/>
+        <ContentControl Content="{Binding AssetID}"/>
+        <ContentControl Content="{Binding ActionType}"/>
+        <ContentControl Content="{Binding ObjectIndex}"/>
+      </StackPanel>
+    </DataTemplate>
+
+    <DataTemplate DataType="{x:Type cmds:FS__}">
+      <StackPanel Classes="form">
+        <TextBlock Classes="formtitle" Text="{Binding LongName}"/>
+        <Separator Classes="formtitle"/>
+        <ContentControl Content="{Binding Basics}"/>
+        <ContentControl Content="{Binding AssetID}"/>
+        <Expander Header="Offset">
+          <StackPanel Classes="form">
+            <ContentControl Content="{Binding X}"/>
+            <ContentControl Content="{Binding Y}"/>
+            <ContentControl Content="{Binding Z}"/>
+          </StackPanel>
+        </Expander>
+        <Expander Header="Rotation">
+          <StackPanel Classes="form">
+            <ContentControl Content="{Binding Yaw}"/>
+            <ContentControl Content="{Binding Pitch}"/>
+            <ContentControl Content="{Binding Roll}"/>
+          </StackPanel>
+        </Expander>
+        <Expander Header="Unknown">
+          <StackPanel Classes="form">
+            <ContentControl Content="{Binding UnkBool}"/>
+            <ContentControl Content="{Binding UnkFloat}"/>
+          </StackPanel>
+        </Expander>
+      </StackPanel>
+    </DataTemplate>
+
+    <DataTemplate DataType="{x:Type cmds:FDFl}">
+      <StackPanel Classes="form">
+        <TextBlock Classes="formtitle" Text="{Binding LongName}"/>
+        <Separator Classes="formtitle"/>
+        <ContentControl Content="{Binding Basics}"/>
+        <ContentControl Content="{Binding AssetID}"/>
+        <ContentControl Content="{Binding Unk}"/>
+      </StackPanel>
+    </DataTemplate>
+
+    <DataTemplate DataType="{x:Type cmds:FGFl}">
+      <StackPanel Classes="form">
+        <TextBlock Classes="formtitle" Text="{Binding LongName}"/>
+        <Separator Classes="formtitle"/>
+        <ContentControl Content="{Binding Basics}"/>
+        <ContentControl Content="{Binding AssetID}"/>
+        <ContentControl Content="{Binding Unk}"/>
+      </StackPanel>
+    </DataTemplate>
+
     <DataTemplate DataType="{x:Type cmds:FrJ_}">
       <StackPanel Classes="form">
         <TextBlock Classes="formtitle" Text="{Binding LongName}"/>

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/FAA_.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/FAA_.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using Serialization;
+
+namespace EVTUI;
+
+public partial class CommandTypes
+{
+    public class FAA_ : ISerializable
+    {
+        public const int DataSize = 80;
+
+        public UInt32 Unk = 174;
+        public UInt32 ObjectIndex;
+
+        public Bitfield32 Flags = new Bitfield32();
+
+        public AnimationStruct FirstAnimation = new AnimationStruct(loopBool:0, endingFrame:0, weight:1.0F);
+        public AnimationStruct SecondAnimation = new AnimationStruct(loopBool:0, endingFrame:0, weight:1.0F);
+
+        public UInt32[] UNUSED_UINT32 = new UInt32[3];
+
+        public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
+        {
+            rw.RwUInt32(ref this.Unk);
+            rw.RwUInt32(ref this.ObjectIndex);
+
+            rw.RwObj(ref this.Flags);
+
+            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
+
+            rw.RwUInt32(ref this.FirstAnimation.Index);
+            rw.RwUInt32(ref this.FirstAnimation.StartingFrame);
+            rw.RwUInt32(ref this.FirstAnimation.EndingFrame);
+            rw.RwUInt32(ref this.FirstAnimation.InterpolatedFrames);
+            rw.RwUInt32(ref this.FirstAnimation.LoopBool);
+            rw.RwFloat32(ref this.FirstAnimation.Weight);
+            rw.RwFloat32(ref this.FirstAnimation.PlaybackSpeed);
+
+            rw.RwUInt32(ref this.UNUSED_UINT32[1]);
+
+            rw.RwUInt32(ref this.SecondAnimation.Index);
+            rw.RwUInt32(ref this.SecondAnimation.StartingFrame);
+            rw.RwUInt32(ref this.SecondAnimation.EndingFrame);
+            rw.RwUInt32(ref this.SecondAnimation.InterpolatedFrames);
+            rw.RwUInt32(ref this.SecondAnimation.LoopBool);
+            rw.RwFloat32(ref this.SecondAnimation.Weight);
+            rw.RwFloat32(ref this.SecondAnimation.PlaybackSpeed);
+
+            rw.RwUInt32(ref this.UNUSED_UINT32[2]);
+
+            for (int i=1; i<this.UNUSED_UINT32.Length; i++)
+                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
+        }
+    }
+}

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/FAB_.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/FAB_.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using Serialization;
+
+namespace EVTUI;
+
+public partial class CommandTypes
+{
+    public class FAB_ : ISerializable
+    {
+        public const int DataSize = 80;
+
+        public Bitfield32 Flags = new Bitfield32();
+        public UInt32 ObjectIndex;
+
+        public AnimationStruct FirstAnimation = new AnimationStruct(loopBool:0, endingFrame:0);
+        public AnimationStruct SecondAnimation = new AnimationStruct(loopBool:0, endingFrame:0);
+
+        public UInt32[] UNUSED_UINT32 = new UInt32[6];
+
+        public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
+        {
+            rw.RwObj(ref this.Flags);
+            rw.RwUInt32(ref this.ObjectIndex);
+
+            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
+            rw.RwUInt32(ref this.UNUSED_UINT32[1]);
+
+            rw.RwUInt32(ref this.FirstAnimation.Index);
+            rw.RwUInt32(ref this.FirstAnimation.StartingFrame);
+            rw.RwUInt32(ref this.FirstAnimation.EndingFrame);
+            rw.RwUInt32(ref this.FirstAnimation.InterpolatedFrames);
+            rw.RwUInt32(ref this.FirstAnimation.LoopBool);
+            rw.RwFloat32(ref this.FirstAnimation.PlaybackSpeed);
+
+            rw.RwUInt32(ref this.UNUSED_UINT32[2]);
+            rw.RwUInt32(ref this.UNUSED_UINT32[3]);
+
+            rw.RwUInt32(ref this.SecondAnimation.Index);
+            rw.RwUInt32(ref this.SecondAnimation.StartingFrame);
+            rw.RwUInt32(ref this.SecondAnimation.EndingFrame);
+            rw.RwUInt32(ref this.SecondAnimation.InterpolatedFrames);
+            rw.RwUInt32(ref this.SecondAnimation.LoopBool);
+            rw.RwFloat32(ref this.SecondAnimation.PlaybackSpeed);
+
+            rw.RwUInt32(ref this.UNUSED_UINT32[4]);
+            rw.RwUInt32(ref this.UNUSED_UINT32[5]);
+
+            for (int i=1; i<this.UNUSED_UINT32.Length; i++)
+                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
+        }
+    }
+}

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/FDFl.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/FDFl.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using Serialization;
+
+namespace EVTUI;
+
+public partial class CommandTypes
+{
+    public class FDFl : ISerializable
+    {
+        public const int DataSize = 16;
+
+        public UInt32 Unk1;
+        public UInt32 Unk2 = 4354;
+
+        public UInt32[] UNUSED_UINT32 = new UInt32[2];
+
+        public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
+        {
+            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
+            Trace.Assert(this.UNUSED_UINT32[0] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[0]}) in reserve variable.");
+
+            rw.RwUInt32(ref this.Unk1);
+            rw.RwUInt32(ref this.Unk2);
+
+            rw.RwUInt32(ref this.UNUSED_UINT32[1]);
+            Trace.Assert(this.UNUSED_UINT32[1] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[1]}) in reserve variable.");
+        }
+    }
+}

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/FGFl.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/FGFl.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using Serialization;
+
+namespace EVTUI;
+
+public partial class CommandTypes
+{
+    public class FGFl : ISerializable
+    {
+        public const int DataSize = 16;
+
+        public UInt32 Unk;
+
+        public UInt32[] UNUSED_UINT32 = new UInt32[3];
+
+        public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
+        {
+            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
+
+            rw.RwUInt32(ref this.Unk);
+
+            rw.RwUInt32(ref this.UNUSED_UINT32[1]);
+            rw.RwUInt32(ref this.UNUSED_UINT32[2]);
+            
+            for (int i=0; i<this.UNUSED_UINT32.Length; i++)
+                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
+        }
+    }
+}

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/FOD_.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/FOD_.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using Serialization;
+
+namespace EVTUI;
+
+public partial class CommandTypes
+{
+    public class FOD_ : ISerializable
+    {
+        public const int DataSize = 16;
+
+        public UInt32 EnableFieldObject;
+        public UInt32 ObjectIndex;
+
+        public UInt32[] UNUSED_UINT32 = new UInt32[2];
+
+        public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
+        {
+            rw.RwUInt32(ref this.EnableFieldObject);
+            rw.RwUInt32(ref this.ObjectIndex);
+
+            for (int i=0; i<this.UNUSED_UINT32.Length; i++)
+            {
+                rw.RwUInt32(ref this.UNUSED_UINT32[i]);
+                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
+            }
+        }
+    }
+}

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/FS__.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/FS__.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using Serialization;
+
+namespace EVTUI;
+
+public partial class CommandTypes
+{
+    public class FS__ : ISerializable
+    {
+        public const int DataSize = 32;
+
+        public UInt32 UnkBool;
+
+        public float[] Coordinates = new float[3];
+        public float[] Rotation = new float[3];
+
+        public float UnkFloat;
+
+        public UInt32[] UNUSED_UINT32 = new UInt32[4];
+
+        public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
+        {
+            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
+
+            rw.RwUInt32(ref this.UnkBool);
+
+            rw.RwUInt32(ref this.UNUSED_UINT32[1]);
+            rw.RwUInt32(ref this.UNUSED_UINT32[2]);
+
+            rw.RwFloat32s(ref this.Coordinates, 3);
+            rw.RwFloat32s(ref this.Rotation, 3);
+
+            rw.RwFloat32(ref this.UnkFloat);
+
+            rw.RwUInt32(ref this.UNUSED_UINT32[3]);
+
+            for (int i=0; i<this.UNUSED_UINT32.Length; i++)
+                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
+        }
+    }
+}


### PR DESCRIPTION
All field-related commands are now fully parsed and editable in the UI. This includes:

- FAA_
- FAB_
- FDFl
- FGFl
- FOD_
- FS__

Most of these need a lot of testing to confirm/refute/de-UNK, since none of these are editable in the P5 beta editor.

For a future PR:
- Get field model previews to actually work
- Determine what on earth the deal is with `FDFl` and `FGFl`