### PR TITLE
Implement all ENV-related commands

### DIFF
--- a/src/gui/EditorWindow/TimelinePanel/CommandViewModels/CClp.cs
+++ b/src/gui/EditorWindow/TimelinePanel/CommandViewModels/CClp.cs
@@ -7,7 +7,7 @@ public class CClp : Generic
         this.LongName = "Camera: Clipping Distance";
 
         this.NearClip = new NumRangeField("Near Clip", this.Editable, this.CommandData.NearClip, 1, 1000, 1);
-        this.FarClip = new NumRangeField("Far Clip", this.Editable, this.CommandData.FarClip, 1, 999999, 1);
+        this.FarClip = new NumRangeField("Far Clip", this.Editable, this.CommandData.FarClip, 1, 1000000, 1);
     }
 
     public NumRangeField NearClip { get; set; }

--- a/src/gui/EditorWindow/TimelinePanel/CommandViewModels/CMC_.cs
+++ b/src/gui/EditorWindow/TimelinePanel/CommandViewModels/CMC_.cs
@@ -26,7 +26,7 @@ public class CMC_ : Generic
         this.FocalDistance = new NumRangeField("Focal Distance", this.Editable, this.CommandData.FocalPlaneDistance, 0, 999999, 1);
         this.NearBlurDistance = new NumRangeField("Near Blur Distance", this.Editable, this.CommandData.NearBlurSurface, 0, 999999, 1);
         this.FarBlurDistance = new NumRangeField("Far Blur Distance", this.Editable, this.CommandData.FarBlurSurface, 0, 999999, 1);
-        this.BlurStrength = new NumRangeField("Blur Strength", this.Editable, this.CommandData.BlurStrength, 0, 1, 0.1);
+        this.BlurStrength = new NumRangeField("Blur Strength", this.Editable, this.CommandData.BlurStrength, 0.5, 1, 0.01);
         this.BlurType = new StringSelectionField("Blur Type", this.Editable, this.BlurTypes.Backward[this.CommandData.BlurType], this.BlurTypes.Keys);
 
         // message

--- a/src/gui/EditorWindow/TimelinePanel/CommandViewModels/CMD_.cs
+++ b/src/gui/EditorWindow/TimelinePanel/CommandViewModels/CMD_.cs
@@ -31,7 +31,7 @@ public class CMD_ : Generic
         this.FocalDistance = new NumRangeField("Focal Distance", this.Editable, this.CommandData.FocalPlaneDistance, 0, 999999, 1);
         this.NearBlurDistance = new NumRangeField("Near Blur Distance", this.Editable, this.CommandData.NearBlurSurface, 0, 999999, 1);
         this.FarBlurDistance = new NumRangeField("Far Blur Distance", this.Editable, this.CommandData.FarBlurSurface, 0, 999999, 1);
-        this.BlurStrength = new NumRangeField("Blur Strength", this.Editable, this.CommandData.BlurStrength, 0, 1, 0.1);
+        this.BlurStrength = new NumRangeField("Blur Strength", this.Editable, this.CommandData.BlurStrength, 0.5, 1, 0.01);
         this.BlurType = new StringSelectionField("Blur Type", this.Editable, this.BlurTypes.Backward[this.CommandData.BlurType], this.BlurTypes.Keys);
 
     }

--- a/src/gui/EditorWindow/TimelinePanel/CommandViewModels/CSA_.cs
+++ b/src/gui/EditorWindow/TimelinePanel/CommandViewModels/CSA_.cs
@@ -34,7 +34,7 @@ public class CSA_ : Generic
         this.FocalDistance = new NumRangeField("Focal Distance", this.Editable, this.CommandData.FocalPlaneDistance, 0, 999999, 1);
         this.NearBlurDistance = new NumRangeField("Near Blur Distance", this.Editable, this.CommandData.NearBlurSurface, 0, 999999, 1);
         this.FarBlurDistance = new NumRangeField("Far Blur Distance", this.Editable, this.CommandData.FarBlurSurface, 0, 999999, 1);
-        this.BlurStrength = new NumRangeField("Blur Strength", this.Editable, this.CommandData.BlurStrength, 0, 1, 0.1);
+        this.BlurStrength = new NumRangeField("Blur Strength", this.Editable, this.CommandData.BlurStrength, 0.5, 1, 0.01);
         this.BlurType = new StringSelectionField("Blur Type", this.Editable, this.BlurTypes.Backward[this.CommandData.BlurType], this.BlurTypes.Keys);
 
         // message

--- a/src/gui/EditorWindow/TimelinePanel/CommandViewModels/CSDD.cs
+++ b/src/gui/EditorWindow/TimelinePanel/CommandViewModels/CSDD.cs
@@ -24,7 +24,7 @@ public class CSDD : Generic
         this.FocalDistance = new NumRangeField("Focal Distance", this.Editable, this.CommandData.FocalPlaneDistance, 0, 999999, 1);
         this.NearBlurDistance = new NumRangeField("Near Blur Distance", this.Editable, this.CommandData.NearBlurSurface, 0, 999999, 1);
         this.FarBlurDistance = new NumRangeField("Far Blur Distance", this.Editable, this.CommandData.FarBlurSurface, 0, 999999, 1);
-        this.BlurStrength = new NumRangeField("Blur Strength", this.Editable, this.CommandData.BlurStrength, 0, 1, 0.1);
+        this.BlurStrength = new NumRangeField("Blur Strength", this.Editable, this.CommandData.BlurStrength, 0.5, 1, 0.01);
 
         // unknown
         this.UnkBool = new BoolChoiceField("Unknown #1", this.Editable, this.CommandData.Flags[1]);

--- a/src/gui/EditorWindow/TimelinePanel/CommandViewModels/CSD_.cs
+++ b/src/gui/EditorWindow/TimelinePanel/CommandViewModels/CSD_.cs
@@ -28,7 +28,7 @@ public class CSD_ : Generic
         this.FocalDistance = new NumRangeField("Focal Distance", this.Editable, this.CommandData.FocalPlaneDistance, 0, 999999, 1);
         this.NearBlurDistance = new NumRangeField("Near Blur Distance", this.Editable, this.CommandData.NearBlurSurface, 0, 999999, 1);
         this.FarBlurDistance = new NumRangeField("Far Blur Distance", this.Editable, this.CommandData.FarBlurSurface, 0, 999999, 1);
-        this.BlurStrength = new NumRangeField("Blur Strength", this.Editable, this.CommandData.BlurStrength, 0, 1, 0.1);
+        this.BlurStrength = new NumRangeField("Blur Strength", this.Editable, this.CommandData.BlurStrength, 0.5, 1, 0.01);
         this.BlurType = new StringSelectionField("Blur Type", this.Editable, this.BlurTypes.Backward[this.CommandData.BlurType], this.BlurTypes.Keys);
 
         // message

--- a/src/gui/EditorWindow/TimelinePanel/CommandViewModels/EnBc.cs
+++ b/src/gui/EditorWindow/TimelinePanel/CommandViewModels/EnBc.cs
@@ -1,0 +1,18 @@
+namespace EVTUI.ViewModels.TimelineCommands;
+
+public class EnBc : Generic
+{
+    public EnBc(DataManager config, SerialCommand command, object commandData) : base(config, command, commandData)
+    {
+        this.LongName = "Environment: Background Color";
+        this.BackgroundColor = new ColorSelectionField("Background Color", this.Editable, this.CommandData.RGBA);
+    }
+
+    public ColorSelectionField BackgroundColor    { get; set; }
+
+    public new void SaveChanges()
+    {
+        base.SaveChanges();
+        this.CommandData.RGBA = this.BackgroundColor.ToUInt32();
+    }
+}

--- a/src/gui/EditorWindow/TimelinePanel/CommandViewModels/EnCc.cs
+++ b/src/gui/EditorWindow/TimelinePanel/CommandViewModels/EnCc.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+
+using static EVTUI.ViewModels.FieldUtils;
+
+namespace EVTUI.ViewModels.TimelineCommands;
+
+public class EnCc : Generic
+{
+    public EnCc(DataManager config, SerialCommand command, object commandData) : base(config, command, commandData)
+    {
+        this.LongName = "Environment: Color Correction";
+
+        this.ActionType = new StringSelectionField("Mode", this.Editable, this.ActionTypes.Backward[this.CommandData.Enable], this.ActionTypes.Keys);
+
+        // corrections
+        this.Cyan = new NumRangeField("Cyan", this.Editable, this.CommandData.Cyan, -1, 1, 0.01);
+        this.Magenta = new NumRangeField("Magenta", this.Editable, this.CommandData.Magenta, -1, 1, 0.01);
+        this.Yellow = new NumRangeField("Yellow", this.Editable, this.CommandData.Yellow, -1, 1, 0.01);
+        this.Dodge = new NumRangeField("Dodge", this.Editable, this.CommandData.Dodge, 0, 0.99, 0.01);
+        this.Burn = new NumRangeField("Burn", this.Editable, this.CommandData.Burn, 0, 0.99, 0.01);
+
+    }
+
+    public StringSelectionField ActionType { get; set; }
+
+    // corrections
+    public NumRangeField Cyan    { get; set; }
+    public NumRangeField Magenta { get; set; }
+    public NumRangeField Yellow  { get; set; }
+    public NumRangeField Dodge   { get; set; }
+    public NumRangeField Burn    { get; set; }
+
+    public new void SaveChanges()
+    {
+        base.SaveChanges();
+
+        this.CommandData.Enable = this.ActionTypes.Forward[this.ActionType.Choice];
+
+        this.CommandData.Cyan    = (float)this.Cyan.Value;
+        this.CommandData.Magenta = (float)this.Magenta.Value;
+        this.CommandData.Yellow  = (float)this.Yellow.Value;
+        this.CommandData.Dodge   = (float)this.Dodge.Value;
+        this.CommandData.Burn    = (float)this.Burn.Value;
+    }
+
+    public BiDict<string, uint> ActionTypes = new BiDict<string, uint>
+    (
+        new Dictionary<string, uint>
+        {
+            {"Disable", 0},
+            {"Enable",  1},
+        }
+    );
+
+}

--- a/src/gui/EditorWindow/TimelinePanel/CommandViewModels/EnDf.cs
+++ b/src/gui/EditorWindow/TimelinePanel/CommandViewModels/EnDf.cs
@@ -1,0 +1,64 @@
+using System.Collections.Generic;
+
+using static EVTUI.ViewModels.FieldUtils;
+
+namespace EVTUI.ViewModels.TimelineCommands;
+
+public class EnDf : Generic
+{
+    public EnDf(DataManager config, SerialCommand command, object commandData) : base(config, command, commandData)
+    {
+        this.LongName = "Environment: Depth of Field";
+
+        // focus/blur
+        this.FocalDistance = new NumRangeField("Focal Distance", this.Editable, this.CommandData.FocalPlaneDistance, 0, 100, 1);
+        this.NearBlurDistance = new NumRangeField("Near Blur Distance", this.Editable, this.CommandData.NearBlurSurface, 0, 100, 1);
+        this.FarBlurDistance = new NumRangeField("Far Blur Distance", this.Editable, this.CommandData.FarBlurSurface, 0, 100, 1);
+        this.DistanceBlurLimit = new NumRangeField("Distance Blur Limit", this.Editable, this.CommandData.DistanceBlurLimit, 0, 100, 1);
+        this.BlurStrength = new NumRangeField("Blur Strength", this.Editable, this.CommandData.BlurStrength, 0.5, 1, 0.01);
+        this.BlurType = new StringSelectionField("Blur Type", this.Editable, this.BlurTypes.Backward[this.CommandData.BlurType], this.BlurTypes.Keys);
+
+        // unknown
+        this.Unk = new NumEntryField("Unknown", this.Editable, this.CommandData.Unk1, 0, 3, 1);
+    }
+
+    // focus/blur
+    public BoolChoiceField      EnableDOF         { get; set; }
+    public NumRangeField        FocalDistance     { get; set; }
+    public NumRangeField        NearBlurDistance  { get; set; }
+    public NumRangeField        FarBlurDistance   { get; set; }
+    public NumRangeField        DistanceBlurLimit { get; set; }
+    public NumRangeField        BlurStrength      { get; set; }
+    public StringSelectionField BlurType          { get; set; }
+
+    // unknown
+    public NumEntryField Unk { get; set; }
+
+    public new void SaveChanges()
+    {
+        base.SaveChanges();
+
+        this.CommandData.Unk1 = (uint)this.Unk.Value;
+
+        this.CommandData.FocalPlaneDistance = (float)this.FocalDistance.Value;
+        this.CommandData.NearBlurSurface = (float)this.NearBlurDistance.Value;
+        this.CommandData.FarBlurSurface = (float)this.FarBlurDistance.Value;
+
+        this.CommandData.DistanceBlurLimit = (float)this.DistanceBlurLimit.Value;
+
+        this.CommandData.BlurStrength = (float)this.BlurStrength.Value;
+        this.CommandData.BlurType = this.BlurTypes.Forward[this.BlurType.Choice];
+    }
+
+    public BiDict<string, uint> BlurTypes = new BiDict<string, uint>
+    (
+        new Dictionary<string, uint>
+        {
+            {"5x5 Gaussian Filter",  0},
+            {"2-Iteration Gaussian", 1},
+            {"3-Iteration Gaussian", 2},
+            {"5-Iteration Gaussian", 3},
+            {"7-Iteration Gaussian", 4},
+        }
+    );
+}

--- a/src/gui/EditorWindow/TimelinePanel/CommandViewModels/EnFD.cs
+++ b/src/gui/EditorWindow/TimelinePanel/CommandViewModels/EnFD.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+
+using static EVTUI.ViewModels.FieldUtils;
+
+namespace EVTUI.ViewModels.TimelineCommands;
+
+public class EnFD : Generic
+{
+    public EnFD(DataManager config, SerialCommand command, object commandData) : base(config, command, commandData)
+    {
+        this.LongName = "Environment: Fog Distance";
+
+        this.ScaleType = new StringSelectionField("Mode", this.Editable, this.ScaleTypes.Backward[this.CommandData.Mode], this.ScaleTypes.Keys);
+        this.FogColor = new ColorSelectionField("Fog Color", this.Editable, this.CommandData.RGBA);
+
+        // distance/range
+        this.MatchWithCameraClip = new BoolChoiceField("Match to Camera Clip?", this.Editable, this.CommandData.Flags[16]);
+        this.StartDistance = new NumRangeField("Start", this.Editable, this.CommandData.StartDistance, -999999, 999999, 1);
+        this.EndDistance = new NumRangeField("End", this.Editable, this.CommandData.EndDistance, -999999, 999999, 1);
+    }
+
+    public StringSelectionField ScaleType { get; set; }
+    public ColorSelectionField  FogColor  { get; set; }
+
+    // distance/range
+    public BoolChoiceField MatchWithCameraClip { get; set; }
+    public NumRangeField   StartDistance       { get; set; }
+    public NumRangeField   EndDistance         { get; set; }
+
+    public new void SaveChanges()
+    {
+        base.SaveChanges();
+
+        this.CommandData.Flags[16] = this.MatchWithCameraClip.Value;
+
+        this.CommandData.Mode          = this.ScaleTypes.Forward[this.ScaleType.Choice];
+        this.CommandData.StartDistance = (float)this.StartDistance.Value;
+        this.CommandData.EndDistance   = (float)this.EndDistance.Value;
+        this.CommandData.RGBA          = this.FogColor.ToUInt32();
+    }
+
+    public BiDict<string, uint> ScaleTypes = new BiDict<string, uint>
+    (
+        new Dictionary<string, uint>
+        {
+            {"Linear",           0},
+            {"Exponential (v1)", 1},
+            {"Exponential (v2)", 2},
+        }
+    );
+}

--- a/src/gui/EditorWindow/TimelinePanel/CommandViewModels/EnFH.cs
+++ b/src/gui/EditorWindow/TimelinePanel/CommandViewModels/EnFH.cs
@@ -1,0 +1,30 @@
+namespace EVTUI.ViewModels.TimelineCommands;
+
+public class EnFH : Generic
+{
+    public EnFH(DataManager config, SerialCommand command, object commandData) : base(config, command, commandData)
+    {
+        this.LongName = "Environment: Fog Height";
+
+        this.FogColor = new ColorSelectionField("Fog Color", this.Editable, this.CommandData.RGBA);
+
+        // distance/range
+        this.StartHeight = new NumRangeField("Start", this.Editable, this.CommandData.StartHeight, -999999, 999999, 1);
+        this.EndHeight = new NumRangeField("End", this.Editable, this.CommandData.EndHeight, -999999, 999999, 1);
+    }
+
+    public ColorSelectionField  FogColor    { get; set; }
+
+    // distance/range
+    public NumRangeField        StartHeight { get; set; }
+    public NumRangeField        EndHeight   { get; set; }
+
+    public new void SaveChanges()
+    {
+        base.SaveChanges();
+
+        this.CommandData.StartHeight = (float)this.StartHeight.Value;
+        this.CommandData.EndHeight   = (float)this.EndHeight.Value;
+        this.CommandData.RGBA        = this.FogColor.ToUInt32();
+    }
+}

--- a/src/gui/EditorWindow/TimelinePanel/CommandViewModels/EnHd.cs
+++ b/src/gui/EditorWindow/TimelinePanel/CommandViewModels/EnHd.cs
@@ -1,0 +1,88 @@
+namespace EVTUI.ViewModels.TimelineCommands;
+
+public class EnHd : Generic
+{
+    public EnHd(DataManager config, SerialCommand command, object commandData) : base(config, command, commandData)
+    {
+        this.LongName = "Environment: HDR";
+
+        // tone map
+        this.EnableToneMap = new BoolChoiceField("Enable?", this.Editable, this.CommandData.Flags[16]);
+        this.ToneMapMediumBrightness = new NumRangeField("Medium Brightness", this.Editable, this.CommandData.ToneMapMediumBrightness, 0, 10, 0.01);
+        this.ToneMapBloomStrength = new NumRangeField("Bloom Strength", this.Editable, this.CommandData.ToneMapBloomStrength, 0, 4, 0.01);
+        this.ToneMapAdaptiveBrightness = new NumRangeField("Adaptive Brightness", this.Editable, this.CommandData.ToneMapAdaptiveBrightness, 0, 1, 0.01);
+        this.ToneMapAdaptiveBloom = new NumRangeField("Adaptive Bloom", this.Editable, this.CommandData.ToneMapAdaptiveBloom, 0, 1.5, 0.01);
+
+        // star filter
+        this.EnableStarFilter = new BoolChoiceField("Enable?", this.Editable, this.CommandData.Flags[17]);
+        this.StarFilterNumberOfLines = new NumEntryField("Number of Lines", this.Editable, this.CommandData.StarFilterNumberOfLines, 2, 4, 1);
+        this.StarFilterLength = new NumRangeField("Length", this.Editable, this.CommandData.StarFilterLength, 0.1, 2, 0.01);
+        this.StarFilterStrength = new NumRangeField("Strength", this.Editable, this.CommandData.StarFilterStrength, 0, 4, 0.01);
+        this.StarFilterGlareChromaticAberration = new NumRangeField("Glare: Chromatic Aberration", this.Editable, this.CommandData.StarFilterGlareChromaticAberration, 0, 5, 0.01);
+        this.StarFilterGlareTilt = new NumRangeField("Glare: Tilt", this.Editable, this.CommandData.StarFilterGlareTilt, 0, 360, 0.1);
+
+        // unknown
+        this.UnkBool = new BoolChoiceField("Unknown #1", this.Editable, this.CommandData.Flags[18]);
+        this.UnkFloat1 = new NumRangeField("Unknown #2", this.Editable, this.CommandData.UnkFloat1, 0, 100, 0.1);
+        this.UnkFloat2 = new NumRangeField("Unknown #3", this.Editable, this.CommandData.UnkFloat2, 0, 6, 0.01);
+        this.UnkFloat3 = new NumRangeField("Unknown #4", this.Editable, this.CommandData.UnkFloat3, 0, 2, 0.01);
+        this.UnkEnum = new NumEntryField("Unknown #5", this.Editable, this.CommandData.UnkEnum, 1, 2, 1);
+        this.UnkColor1 = new ColorSelectionField("Unknown #6", this.Editable, this.CommandData.RGBA1);
+        this.UnkColor2 = new ColorSelectionField("Unknown #7", this.Editable, this.CommandData.RGBA2);
+        this.UnkColor3 = new ColorSelectionField("Unknown #8", this.Editable, this.CommandData.RGBA3);
+    }
+
+    // tone map
+    public BoolChoiceField EnableToneMap             { get; set; }
+    public NumRangeField   ToneMapMediumBrightness   { get; set; }
+    public NumRangeField   ToneMapBloomStrength      { get; set; }
+    public NumRangeField   ToneMapAdaptiveBrightness { get; set; }
+    public NumRangeField   ToneMapAdaptiveBloom      { get; set; }
+
+    // star filter
+    public BoolChoiceField EnableStarFilter                   { get; set; }
+    public NumEntryField   StarFilterNumberOfLines            { get; set; }
+    public NumRangeField   StarFilterLength                   { get; set; }
+    public NumRangeField   StarFilterStrength                 { get; set; }
+    public NumRangeField   StarFilterGlareChromaticAberration { get; set; }
+    public NumRangeField   StarFilterGlareTilt                { get; set; }
+
+    // unknown
+    public BoolChoiceField     UnkBool   { get; set; }
+    public NumRangeField       UnkFloat1 { get; set; }
+    public NumRangeField       UnkFloat2 { get; set; }
+    public NumRangeField       UnkFloat3 { get; set; }
+    public NumEntryField       UnkEnum   { get; set; }
+    public ColorSelectionField UnkColor1 { get; set; }
+    public ColorSelectionField UnkColor2 { get; set; }
+    public ColorSelectionField UnkColor3 { get; set; }
+
+    public new void SaveChanges()
+    {
+        base.SaveChanges();
+
+        this.CommandData.Flags[16] = this.EnableToneMap.Value;
+        this.CommandData.Flags[17] = this.EnableStarFilter.Value;
+        this.CommandData.Flags[18] = this.UnkBool.Value;
+
+        this.CommandData.ToneMapMediumBrightness   = (float)this.ToneMapMediumBrightness.Value;
+        this.CommandData.ToneMapBloomStrength      = (float)this.ToneMapBloomStrength.Value;
+        this.CommandData.ToneMapAdaptiveBrightness = (float)this.ToneMapAdaptiveBrightness.Value;
+        this.CommandData.ToneMapAdaptiveBloom      = (float)this.ToneMapAdaptiveBloom.Value;
+
+        this.CommandData.StarFilterNumberOfLines            = (uint)this.StarFilterNumberOfLines.Value;
+        this.CommandData.StarFilterLength                   = (float)this.StarFilterLength.Value;
+        this.CommandData.StarFilterStrength                 = (float)this.StarFilterStrength.Value;
+        this.CommandData.StarFilterGlareChromaticAberration = (float)this.StarFilterGlareChromaticAberration.Value;
+        this.CommandData.StarFilterGlareTilt                = (float)this.StarFilterGlareTilt.Value;
+
+        this.CommandData.UnkFloat1 = (float)this.UnkFloat1.Value;
+        this.CommandData.UnkFloat2 = (float)this.UnkFloat2.Value;
+        this.CommandData.UnkFloat3 = (float)this.UnkFloat3.Value;
+
+        this.CommandData.UnkEnum = (uint)this.UnkEnum.Value;
+        this.CommandData.RGBA1   = this.UnkColor1.ToUInt32();
+        this.CommandData.RGBA2   = this.UnkColor2.ToUInt32();
+        this.CommandData.RGBA3   = this.UnkColor3.ToUInt32();
+    }
+}

--- a/src/gui/EditorWindow/TimelinePanel/CommandViewModels/EnL0.cs
+++ b/src/gui/EditorWindow/TimelinePanel/CommandViewModels/EnL0.cs
@@ -1,0 +1,40 @@
+using static EVTUI.ViewModels.FieldUtils;
+
+namespace EVTUI.ViewModels.TimelineCommands;
+
+public class EnL0 : Generic
+{
+    public EnL0(DataManager config, SerialCommand command, object commandData) : base(config, command, commandData)
+    {
+        this.LongName = "Environment: Lighting (Objects)";
+
+        // colors
+        this.AmbientColor = new ColorSelectionField("Ambient", this.Editable, this.CommandData.AmbientRGBA);
+        this.DiffuseColor = new ColorSelectionField("Diffuse", this.Editable, this.CommandData.DiffuseRGBA);
+        this.SpecularColor = new ColorSelectionField("Specular", this.Editable, this.CommandData.SpecularRGBA);
+
+        // direction
+        this.AzimuthDegrees = new NumRangeField("Azimuth", this.Editable, VectorToAzimuth(this.CommandData.Direction), -180, 180, 1);
+        this.ElevationDegrees = new NumRangeField("Elevation", this.Editable, VectorToElevation(this.CommandData.Direction), -90, 90, 1);
+    }
+
+    // colors
+    public ColorSelectionField AmbientColor  { get; set; }
+    public ColorSelectionField DiffuseColor  { get; set; }
+    public ColorSelectionField SpecularColor { get; set; }
+
+    // direction
+    public NumRangeField AzimuthDegrees   { get; set; }
+    public NumRangeField ElevationDegrees { get; set; }
+
+    public new void SaveChanges()
+    {
+        base.SaveChanges();
+
+        this.CommandData.AmbientRGBA = this.AmbientColor.ToUInt32();
+        this.CommandData.DiffuseRGBA = this.DiffuseColor.ToUInt32();
+        this.CommandData.SpecularRGBA = this.SpecularColor.ToUInt32();
+
+        this.CommandData.Direction = AnglesToVector((double)this.AzimuthDegrees.Value, (double)this.ElevationDegrees.Value);
+    }
+}

--- a/src/gui/EditorWindow/TimelinePanel/CommandViewModels/EnLI.cs
+++ b/src/gui/EditorWindow/TimelinePanel/CommandViewModels/EnLI.cs
@@ -1,0 +1,40 @@
+using static EVTUI.ViewModels.FieldUtils;
+
+namespace EVTUI.ViewModels.TimelineCommands;
+
+public class EnLI : Generic
+{
+    public EnLI(DataManager config, SerialCommand command, object commandData) : base(config, command, commandData)
+    {
+        this.LongName = "Environment: Lighting (Characters)";
+
+        // colors
+        this.AmbientColor = new ColorSelectionField("Ambient", this.Editable, this.CommandData.AmbientRGBA);
+        this.DiffuseColor = new ColorSelectionField("Diffuse", this.Editable, this.CommandData.DiffuseRGBA);
+        this.SpecularColor = new ColorSelectionField("Specular", this.Editable, this.CommandData.SpecularRGBA);
+
+        // direction
+        this.AzimuthDegrees = new NumRangeField("Azimuth", this.Editable, VectorToAzimuth(this.CommandData.Direction), -180, 180, 1);
+        this.ElevationDegrees = new NumRangeField("Elevation", this.Editable, VectorToElevation(this.CommandData.Direction), -90, 90, 1);
+    }
+
+    // colors
+    public ColorSelectionField AmbientColor  { get; set; }
+    public ColorSelectionField DiffuseColor  { get; set; }
+    public ColorSelectionField SpecularColor { get; set; }
+
+    // direction
+    public NumRangeField AzimuthDegrees   { get; set; }
+    public NumRangeField ElevationDegrees { get; set; }
+
+    public new void SaveChanges()
+    {
+        base.SaveChanges();
+
+        this.CommandData.AmbientRGBA = this.AmbientColor.ToUInt32();
+        this.CommandData.DiffuseRGBA = this.DiffuseColor.ToUInt32();
+        this.CommandData.SpecularRGBA = this.SpecularColor.ToUInt32();
+
+        this.CommandData.Direction = AnglesToVector((double)this.AzimuthDegrees.Value, (double)this.ElevationDegrees.Value);
+    }
+}

--- a/src/gui/EditorWindow/TimelinePanel/CommandViewModels/EnOl.cs
+++ b/src/gui/EditorWindow/TimelinePanel/CommandViewModels/EnOl.cs
@@ -1,0 +1,34 @@
+namespace EVTUI.ViewModels.TimelineCommands;
+
+public class EnOl : Generic
+{
+    public EnOl(DataManager config, SerialCommand command, object commandData) : base(config, command, commandData)
+    {
+        this.LongName = "Environment: Outline";
+
+        // unknown
+        this.Unk1 = new NumRangeField("Unknown #1", this.Editable, this.CommandData.Strength, 0, 9999, 1);
+        this.Unk2 = new NumRangeField("Unknown #2", this.Editable, this.CommandData.Width, 0, 9999, 1);
+        this.Unk3 = new NumRangeField("Unknown #3", this.Editable, this.CommandData.Brightness, 0, 1, 0.01);
+        this.Unk4 = new NumRangeField("Unknown #4", this.Editable, this.CommandData.RangeMin, 0, 9999, 1);
+        this.Unk5 = new NumRangeField("Unknown #5", this.Editable, this.CommandData.RangeMax, 0, 9999, 1);
+    }
+
+    // direction
+    public NumRangeField Unk1 { get; set; }
+    public NumRangeField Unk2 { get; set; }
+    public NumRangeField Unk3 { get; set; }
+    public NumRangeField Unk4 { get; set; }
+    public NumRangeField Unk5 { get; set; }
+
+    public new void SaveChanges()
+    {
+        base.SaveChanges();
+
+        this.CommandData.Strength   = (float)this.Unk1.Value;
+        this.CommandData.Width      = (float)this.Unk2.Value;
+        this.CommandData.Brightness = (float)this.Unk3.Value;
+        this.CommandData.RangeMin   = (float)this.Unk4.Value;
+        this.CommandData.RangeMax   = (float)this.Unk5.Value;
+    }
+}

--- a/src/gui/EditorWindow/TimelinePanel/CommandViewModels/EnPh.cs
+++ b/src/gui/EditorWindow/TimelinePanel/CommandViewModels/EnPh.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace EVTUI.ViewModels.TimelineCommands;
+
+public class EnPh : Generic
+{
+    public EnPh(DataManager config, SerialCommand command, object commandData) : base(config, command, commandData)
+    {
+        this.LongName = "Environment: Physics";
+
+        this.Enabled = new BoolChoiceField("Enable Physics?", this.Editable, this.CommandData.Enable != 0);
+    }
+
+    public BoolChoiceField Enabled { get; set; }
+
+    public new void SaveChanges()
+    {
+        base.SaveChanges();
+
+        this.CommandData.Enable = Convert.ToUInt32(this.Enabled.Value);
+    }
+}

--- a/src/gui/EditorWindow/TimelinePanel/CommandViewModels/EnSh.cs
+++ b/src/gui/EditorWindow/TimelinePanel/CommandViewModels/EnSh.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+
+namespace EVTUI.ViewModels.TimelineCommands;
+
+public class EnSh : Generic
+{
+    public EnSh(DataManager config, SerialCommand command, object commandData) : base(config, command, commandData)
+    {
+        this.LongName = "Environment: Shadows";
+
+        this.SetCameraClip = new BoolChoiceField("Set Camera Far Clip to Depth Range?", this.Editable, this.CommandData.Flags[0]);
+        this.BackSideDrawingEnabled = new BoolChoiceField("Enable Back Side Drawing?", this.Editable, this.CommandData.Flags[3]);
+
+        this.DepthRange = new NumRangeField("Depth Range", this.Editable, this.CommandData.DepthRange, 0, 9999, 1);
+        this.Bias = new NumRangeField("Bias", this.Editable, this.CommandData.Bias, -3, 3, 0.01);
+        this.Ambient = new NumRangeField("Ambient", this.Editable, this.CommandData.Ambient, 0, 1, 0.01);
+        this.Diffuse = new NumRangeField("Diffuse", this.Editable, this.CommandData.Diffuse, 0, 1, 0.01);
+        this.CascadedShadowMapPartitionInterval = new NumRangeField("Cascaded Shadow Map Partition Interval", this.Editable, this.CommandData.CascadedShadowMapPartitionInterval, 0.01, 0.99, 0.01);
+    }
+
+    public BoolChoiceField SetCameraClip          { get; set; }
+    public BoolChoiceField BackSideDrawingEnabled { get; set; }
+
+    public NumRangeField DepthRange                         { get; set; }
+    public NumRangeField Bias                               { get; set; }
+    public NumRangeField Ambient                            { get; set; }
+    public NumRangeField Diffuse                            { get; set; }
+    public NumRangeField CascadedShadowMapPartitionInterval { get; set; }
+
+    public new void SaveChanges()
+    {
+        base.SaveChanges();
+
+        this.CommandData.Flags[0] = this.SetCameraClip.Value;
+        this.CommandData.Flags[3] = this.BackSideDrawingEnabled.Value;
+
+        this.CommandData.DepthRange = (float)this.DepthRange.Value;
+        this.CommandData.Bias = (float)this.Bias.Value;
+        this.CommandData.Ambient = (float)this.Ambient.Value;
+        this.CommandData.Diffuse = (float)this.Diffuse.Value;
+        this.CommandData.CascadedShadowMapPartitionInterval = (float)this.CascadedShadowMapPartitionInterval.Value;
+    }
+}

--- a/src/gui/EditorWindow/TimelinePanel/CommandViewModels/EnSs.cs
+++ b/src/gui/EditorWindow/TimelinePanel/CommandViewModels/EnSs.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+
+namespace EVTUI.ViewModels.TimelineCommands;
+
+public class EnSs : Generic
+{
+    public EnSs(DataManager config, SerialCommand command, object commandData) : base(config, command, commandData)
+    {
+        this.LongName = "Environment: SSAO";
+
+        this.Enabled = new BoolChoiceField("Enable Screen Space Ambient Occlusion (SSAO)?", this.Editable, this.CommandData.Enable != 0);
+
+        this.Range = new NumRangeField("Range", this.Editable, this.CommandData.Range, 0, 1000, 1);
+        this.Radius = new NumRangeField("Radius", this.Editable, this.CommandData.Radius, 0, 3, 0.01);
+        this.Attenuation = new NumRangeField("Attenuation", this.Editable, this.CommandData.Attenuation, 0.01, 1.0, 0.01);
+        this.Concentration = new NumRangeField("Concentration", this.Editable, this.CommandData.Concentration, 0.01, 5.0, 0.01);
+        this.Blur = new NumRangeField("Blur", this.Editable, this.CommandData.Blur, 0, 5, 0.01);
+    }
+
+    public BoolChoiceField Enabled { get; set; }
+
+    public NumRangeField Range         { get; set; }
+    public NumRangeField Radius        { get; set; }
+    public NumRangeField Attenuation   { get; set; }
+    public NumRangeField Concentration { get; set; }
+    public NumRangeField Blur          { get; set; }
+
+    public new void SaveChanges()
+    {
+        base.SaveChanges();
+
+        this.CommandData.Enable = Convert.ToUInt32(this.Enabled.Value);
+
+        this.CommandData.Range = (float)this.Range.Value;
+        this.CommandData.Radius = (float)this.Radius.Value;
+        this.CommandData.Attenuation = (float)this.Attenuation.Value;
+        this.CommandData.Concentration = (float)this.Concentration.Value;
+        this.CommandData.Blur = (float)this.Blur.Value;
+    }
+}

--- a/src/gui/EditorWindow/TimelinePanel/CommandViewModels/Env_.cs
+++ b/src/gui/EditorWindow/TimelinePanel/CommandViewModels/Env_.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace EVTUI.ViewModels.TimelineCommands;
+
+public class Env_ : Generic
+{
+    public Env_(DataManager config, SerialCommand command, object commandData) : base(config, command, commandData)
+    {
+        this.LongName = "Environment: Load";
+
+        this.AssetID = new IntSelectionField("Asset ID", this.Editable, this.CommandData.ObjectId, config.EventManager.AssetIDsOfType(0x00000004));
+    }
+
+    public IntSelectionField AssetID { get; set; }
+
+    public new void SaveChanges()
+    {
+        base.SaveChanges();
+        this.CommandData.ObjectId = this.AssetID.Choice;
+    }
+}

--- a/src/gui/EditorWindow/TimelinePanel/CommandViewModels/FOD_.cs
+++ b/src/gui/EditorWindow/TimelinePanel/CommandViewModels/FOD_.cs
@@ -12,7 +12,7 @@ public class FOD_ : Generic
         this.AssetID = new IntSelectionField("Asset ID", this.Editable, this.Command.ObjectId, config.EventManager.AssetIDsOfType(0x00000003));
 
         this.ActionType = new StringSelectionField("Mode", this.Editable, this.ActionTypes.Backward[this.CommandData.EnableFieldObject], this.ActionTypes.Keys);
-        this.ObjectIndex = new NumEntryField("Field Object Index", this.Editable, this.CommandData.ObjectIndex, 0, 65535, 1);
+        this.ObjectIndex = new NumEntryField("Field Object Index", this.Editable, this.CommandData.ObjectIndex, -1, 65535, 1);
 
     }
 
@@ -27,7 +27,7 @@ public class FOD_ : Generic
         this.Command.ObjectId = this.AssetID.Choice;
 
         this.CommandData.EnableFieldObject = this.ActionTypes.Forward[this.ActionType.Choice];
-        this.CommandData.ObjectIndex       = (uint)this.ObjectIndex.Value;
+        this.CommandData.ObjectIndex       = (int)this.ObjectIndex.Value;
     }
 
     public BiDict<string, uint> ActionTypes = new BiDict<string, uint>

--- a/src/gui/EditorWindow/TimelinePanel/CommandViewModels/ML__.cs
+++ b/src/gui/EditorWindow/TimelinePanel/CommandViewModels/ML__.cs
@@ -1,5 +1,6 @@
 using System;
-using System.Numerics;
+
+using static EVTUI.ViewModels.FieldUtils;
 
 namespace EVTUI.ViewModels.TimelineCommands;
 
@@ -24,31 +25,6 @@ public class ML__ : Generic
         //this.BackToFront = new NumRangeField("Back-to-Front", false, this.CommandData.Direction[2], -1, 1, 0.1);
         this.AzimuthDegrees = new NumRangeField("Azimuth", this.Editable, VectorToAzimuth(this.CommandData.Direction), -180, 180, 1);
         this.ElevationDegrees = new NumRangeField("Elevation", this.Editable, VectorToElevation(this.CommandData.Direction), -90, 90, 1);
-    }
-
-    private static double VectorToAzimuth(float[] xyz)
-    {
-        return Double.RadiansToDegrees(Math.Atan2(xyz[0], xyz[2]));
-    }
-
-    private static double VectorToElevation(float[] xyz)
-    {
-        if (xyz[0] == 0 && xyz[2] == 0)
-           return (xyz[1] < 0) ? -90.0 : 90.0;
-        Vector3 direction = new Vector3(xyz[0], xyz[1], xyz[2]);
-        Vector3 projection = new Vector3(xyz[0], 0, xyz[2]);
-        return Double.RadiansToDegrees(((xyz[1] < 0) ? -1.0 : 1.0)*Math.Acos(Vector3.Dot(Vector3.Normalize(direction), Vector3.Normalize(projection))));
-    }
-
-    private static float[] AnglesToVector(double azimuth, double elevation)
-    {
-        azimuth = Double.DegreesToRadians(azimuth);
-        elevation = Double.DegreesToRadians(elevation);
-        double x = Math.Cos(elevation)*Math.Sin(azimuth);
-        double y = Math.Sin(elevation);
-        double z = Math.Cos(elevation)*Math.Cos(azimuth);
-        Vector3 norm = Vector3.Normalize(new Vector3((float)x, (float)y, (float)z));
-        return new float[] { norm.X, norm.Y, norm.Z };
     }
 
     public IntSelectionField AssetID { get; set; }

--- a/src/gui/EditorWindow/TimelinePanel/TimelinePanel.axaml
+++ b/src/gui/EditorWindow/TimelinePanel/TimelinePanel.axaml
@@ -518,6 +518,237 @@
       </StackPanel>
     </DataTemplate>
 
+    <DataTemplate DataType="{x:Type cmds:EnBc}">
+      <StackPanel Classes="form">
+        <TextBlock Classes="formtitle" Text="{Binding LongName}"/>
+        <Separator Classes="formtitle"/>
+        <ContentControl Content="{Binding Basics}"/>
+        <ContentControl Content="{Binding BackgroundColor}"/>
+      </StackPanel>
+    </DataTemplate>
+
+    <DataTemplate DataType="{x:Type cmds:EnCc}">
+      <StackPanel Classes="form">
+        <TextBlock Classes="formtitle" Text="{Binding LongName}"/>
+        <Separator Classes="formtitle"/>
+        <ContentControl Content="{Binding Basics}"/>
+        <ContentControl Content="{Binding ActionType}"/>
+        <Expander Header="Corrections" IsVisible="{c:Binding 'ActionType.Choice == \'Enable\''}">
+          <StackPanel Classes="form">
+            <ContentControl Content="{Binding Cyan}"/>
+            <ContentControl Content="{Binding Magenta}"/>
+            <ContentControl Content="{Binding Yellow}"/>
+            <ContentControl Content="{Binding Dodge}"/>
+            <ContentControl Content="{Binding Burn}"/>
+          </StackPanel>
+        </Expander>
+      </StackPanel>
+    </DataTemplate>
+
+    <DataTemplate DataType="{x:Type cmds:EnDf}">
+      <StackPanel Classes="form">
+        <TextBlock Classes="formtitle" Text="{Binding LongName}"/>
+        <Separator Classes="formtitle"/>
+        <ContentControl Content="{Binding Basics}"/>
+        <ContentControl Content="{Binding FocalDistance}"/>
+        <ContentControl Content="{Binding NearBlurDistance}"/>
+        <ContentControl Content="{Binding FarBlurDistance}"/>
+        <ContentControl Content="{Binding DistanceBlurLimit}"/>
+        <ContentControl Content="{Binding BlurStrength}"/>
+        <ContentControl Content="{Binding BlurType}"/>
+        <Expander Header="Unknown">
+          <StackPanel Classes="form">
+            <ContentControl Content="{Binding Unk}"/>
+          </StackPanel>
+        </Expander>
+      </StackPanel>
+    </DataTemplate>
+
+    <DataTemplate DataType="{x:Type cmds:EnFD}">
+      <StackPanel Classes="form">
+        <TextBlock Classes="formtitle" Text="{Binding LongName}"/>
+        <Separator Classes="formtitle"/>
+        <ContentControl Content="{Binding Basics}"/>
+        <ContentControl Content="{Binding ScaleType}"/>
+        <ContentControl Content="{Binding FogColor}"/>
+        <Expander Header="Range (Distance)">
+          <StackPanel Classes="form">
+            <ContentControl Content="{Binding MatchWithCameraClip}"/>
+            <ContentControl Content="{Binding StartDistance}" IsVisible="{Binding !MatchWithCameraClip.Value}"/>
+            <ContentControl Content="{Binding EndDistance}" IsVisible="{Binding !MatchWithCameraClip.Value}"/>
+          </StackPanel>
+        </Expander>
+      </StackPanel>
+    </DataTemplate>
+
+    <DataTemplate DataType="{x:Type cmds:EnFH}">
+      <StackPanel Classes="form">
+        <TextBlock Classes="formtitle" Text="{Binding LongName}"/>
+        <Separator Classes="formtitle"/>
+        <ContentControl Content="{Binding Basics}"/>
+        <ContentControl Content="{Binding FogColor}"/>
+        <Expander Header="Range (Height)">
+          <StackPanel Classes="form">
+            <ContentControl Content="{Binding StartHeight}"/>
+            <ContentControl Content="{Binding EndHeight}"/>
+          </StackPanel>
+        </Expander>
+      </StackPanel>
+    </DataTemplate>
+
+    <DataTemplate DataType="{x:Type cmds:EnHd}">
+      <StackPanel Classes="form">
+        <TextBlock Classes="formtitle" Text="{Binding LongName}"/>
+        <Separator Classes="formtitle"/>
+        <ContentControl Content="{Binding Basics}"/>
+        <Expander Header="Tone Map">
+          <StackPanel Classes="form">
+            <ContentControl Content="{Binding EnableToneMap}"/>
+            <StackPanel Classes="form" IsVisible="{Binding EnableToneMap.Value}">
+              <ContentControl Content="{Binding ToneMapMediumBrightness}"/>
+              <ContentControl Content="{Binding ToneMapBloomStrength}"/>
+              <ContentControl Content="{Binding ToneMapAdaptiveBrightness}"/>
+              <ContentControl Content="{Binding ToneMapAdaptiveBloom}"/>
+            </StackPanel>
+          </StackPanel>
+        </Expander>
+        <Expander Header="Star Filter">
+          <StackPanel Classes="form">
+            <ContentControl Content="{Binding EnableStarFilter}"/>
+            <StackPanel Classes="form" IsVisible="{Binding EnableStarFilter.Value}">
+              <ContentControl Content="{Binding StarFilterNumberOfLines}"/>
+              <ContentControl Content="{Binding StarFilterLength}"/>
+              <ContentControl Content="{Binding StarFilterStrength}"/>
+              <ContentControl Content="{Binding StarFilterGlareChromaticAberration}"/>
+              <ContentControl Content="{Binding StarFilterGlareTilt}"/>
+            </StackPanel>
+          </StackPanel>
+        </Expander>
+        <Expander Header="Unknown">
+          <StackPanel Classes="form">
+            <ContentControl Content="{Binding UnkFloat1}"/>
+            <ContentControl Content="{Binding UnkFloat2}"/>
+            <ContentControl Content="{Binding UnkFloat3}"/>
+            <StackPanel Classes="form" IsVisible="{c:Binding 'Size > 64'}">
+              <ContentControl Content="{Binding UnkBool}"/>
+              <ContentControl Content="{Binding UnkEnum}"/>
+              <ContentControl Content="{Binding UnkColor1}"/>
+              <ContentControl Content="{Binding UnkColor2}"/>
+              <ContentControl Content="{Binding UnkColor3}"/>
+            </StackPanel>
+          </StackPanel>
+        </Expander>
+      </StackPanel>
+    </DataTemplate>
+
+    <DataTemplate DataType="{x:Type cmds:EnL0}">
+      <StackPanel Classes="form">
+        <TextBlock Classes="formtitle" Text="{Binding LongName}"/>
+        <Separator Classes="formtitle"/>
+        <ContentControl Content="{Binding Basics}"/>
+        <Expander Header="Color">
+          <StackPanel Classes="form">
+            <ContentControl Content="{Binding AmbientColor}"/>
+            <ContentControl Content="{Binding DiffuseColor}"/>
+            <ContentControl Content="{Binding SpecularColor}"/>
+          </StackPanel>
+        </Expander>
+        <Expander Header="Direction (Degrees)">
+          <StackPanel Classes="form">
+            <ContentControl Content="{Binding AzimuthDegrees}"/>
+            <ContentControl Content="{Binding ElevationDegrees}"/>
+          </StackPanel>
+        </Expander>
+      </StackPanel>
+    </DataTemplate>
+
+    <DataTemplate DataType="{x:Type cmds:EnLI}">
+      <StackPanel Classes="form">
+        <TextBlock Classes="formtitle" Text="{Binding LongName}"/>
+        <Separator Classes="formtitle"/>
+        <ContentControl Content="{Binding Basics}"/>
+        <Expander Header="Color">
+          <StackPanel Classes="form">
+            <ContentControl Content="{Binding AmbientColor}"/>
+            <ContentControl Content="{Binding DiffuseColor}"/>
+            <ContentControl Content="{Binding SpecularColor}"/>
+          </StackPanel>
+        </Expander>
+        <Expander Header="Direction (Degrees)">
+          <StackPanel Classes="form">
+            <ContentControl Content="{Binding AzimuthDegrees}"/>
+            <ContentControl Content="{Binding ElevationDegrees}"/>
+          </StackPanel>
+        </Expander>
+      </StackPanel>
+    </DataTemplate>
+
+    <DataTemplate DataType="{x:Type cmds:EnOl}">
+      <StackPanel Classes="form">
+        <TextBlock Classes="formtitle" Text="{Binding LongName}"/>
+        <Separator Classes="formtitle"/>
+        <ContentControl Content="{Binding Basics}"/>
+        <Expander Header="Unknown">
+          <StackPanel Classes="form">
+            <ContentControl Content="{Binding Unk1}"/>
+            <ContentControl Content="{Binding Unk2}"/>
+            <ContentControl Content="{Binding Unk3}"/>
+            <ContentControl Content="{Binding Unk4}"/>
+            <ContentControl Content="{Binding Unk5}"/>
+          </StackPanel>
+        </Expander>
+      </StackPanel>
+    </DataTemplate>
+
+    <DataTemplate DataType="{x:Type cmds:EnPh}">
+      <StackPanel Classes="form">
+        <TextBlock Classes="formtitle" Text="{Binding LongName}"/>
+        <Separator Classes="formtitle"/>
+        <ContentControl Content="{Binding Basics}"/>
+        <ContentControl Content="{Binding Enabled}"/>
+      </StackPanel>
+    </DataTemplate>
+
+    <DataTemplate DataType="{x:Type cmds:EnSh}">
+      <StackPanel Classes="form">
+        <TextBlock Classes="formtitle" Text="{Binding LongName}"/>
+        <Separator Classes="formtitle"/>
+        <ContentControl Content="{Binding Basics}"/>
+        <ContentControl Content="{Binding SetCameraClip}"/>
+        <ContentControl Content="{Binding BackSideDrawingEnabled}"/>
+        <ContentControl Content="{Binding DepthRange}"/>
+        <ContentControl Content="{Binding Bias}"/>
+        <ContentControl Content="{Binding Ambient}"/>
+        <ContentControl Content="{Binding Diffuse}"/>
+        <ContentControl Content="{Binding CascadedShadowMapPartitionInterval}"/>
+      </StackPanel>
+    </DataTemplate>
+
+    <DataTemplate DataType="{x:Type cmds:EnSs}">
+      <StackPanel Classes="form">
+        <TextBlock Classes="formtitle" Text="{Binding LongName}"/>
+        <Separator Classes="formtitle"/>
+        <ContentControl Content="{Binding Basics}"/>
+        <ContentControl Content="{Binding Enabled}"/>
+        <StackPanel Classes="form" IsVisible="{Binding Enabled.Value}">
+          <ContentControl Content="{Binding Range}"/>
+          <ContentControl Content="{Binding Radius}"/>
+          <ContentControl Content="{Binding Attenuation}"/>
+          <ContentControl Content="{Binding Concentration}"/>
+          <ContentControl Content="{Binding Blur}"/>
+        </StackPanel>
+      </StackPanel>
+    </DataTemplate>
+
+    <DataTemplate DataType="{x:Type cmds:Env_}">
+      <StackPanel Classes="form">
+        <TextBlock Classes="formtitle" Text="{Binding LongName}"/>
+        <Separator Classes="formtitle"/>
+        <ContentControl Content="{Binding Basics}"/>
+        <ContentControl Content="{Binding AssetID}"/>
+      </StackPanel>
+    </DataTemplate>
+
     <DataTemplate DataType="{x:Type cmds:FAA_}">
       <StackPanel Classes="form">
         <TextBlock Classes="formtitle" Text="{Binding LongName}"/>

--- a/src/gui/Utilities/FieldUtils.cs
+++ b/src/gui/Utilities/FieldUtils.cs
@@ -1,55 +1,41 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Numerics;
 
 namespace EVTUI.ViewModels;
 
 public static class FieldUtils
 {
 
-    // deprecated in favor of BiDict, but leaving in for posterity... for now
-    /*public static List<string> NameList(Enum _enum, bool replaceUnderscores = true)
+    /*************************/
+    /*** UNIT VECTOR UTILS ***/
+    /*************************/
+
+    public static double VectorToAzimuth(float[] xyz)
     {
-        if (replaceUnderscores)
-            return (Enum.GetNames(_enum.GetType())).Select(x => x.Replace("__", " ").Replace("_", "-")).ToList();
-        else
-            return (Enum.GetNames(_enum.GetType())).ToList();
+        return Double.RadiansToDegrees(Math.Atan2(xyz[0], xyz[2]));
     }
 
-    public static string NumToName(Enum _enum, dynamic val, bool replaceUnderscores = true)
+    public static double VectorToElevation(float[] xyz)
     {
-        if (replaceUnderscores)
-            return Enum.GetName(_enum.GetType(), val).Replace("__", " ").Replace("_", "-");
-        else
-            return Enum.GetName(_enum.GetType(), val);
+        if (xyz[0] == 0 && xyz[2] == 0)
+            return (xyz[1] < 0) ? -90.0 : 90.0;
+        Vector3 direction = new Vector3(xyz[0], xyz[1], xyz[2]);
+        Vector3 projection = new Vector3(xyz[0], 0, xyz[2]);
+        return Double.RadiansToDegrees(((xyz[1] < 0) ? -1.0 : 1.0)*Math.Acos(Vector3.Dot(Vector3.Normalize(direction), Vector3.Normalize(projection))));
     }
 
-    public static dynamic NameToNum(Enum _enum, string name, bool replaceUnderscores = true)
+    public static float[] AnglesToVector(double azimuth, double elevation)
     {
-        if (replaceUnderscores)
-            return Enum.Parse(_enum.GetType(), name.Replace(" ", "__").Replace("-", "_"));
-        else
-            return Enum.Parse(_enum.GetType(), name);
-    }*/
-
-    // also deprecated because i moved bitfield stuff into the view and not the viewmodel......
-    // well.... i will still leave this here for a bit just in case
-    /*public static bool BitToBool(uint field, int pos)
-    {
-        return (((field >> pos) & 1) != 0);
+        azimuth = Double.DegreesToRadians(azimuth);
+        elevation = Double.DegreesToRadians(elevation);
+        double x = Math.Cos(elevation)*Math.Sin(azimuth);
+        double y = Math.Sin(elevation);
+        double z = Math.Cos(elevation)*Math.Cos(azimuth);
+        Vector3 norm = Vector3.Normalize(new Vector3((float)x, (float)y, (float)z));
+        return new float[] { norm.X, norm.Y, norm.Z };
     }
-
-    // useless because properties can't be passed by reference...
-    //public static void SetBit(ref dynamic field, int pos, bool val)
-    //{
-    //    field &= ~(1 << pos);
-    //    field |= (Convert.ToInt32(val) << pos);
-    //}
-
-    public static int BoolToBit(bool val, int pos)
-    {
-        return Convert.ToInt32(val) << pos;
-    }*/
 
 }
 

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/EnBc.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/EnBc.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using Serialization;
+
+namespace EVTUI;
+
+public partial class CommandTypes
+{
+    public class EnBc : ISerializable
+    {
+        public const int DataSize = 16;
+
+        public UInt32 Unk = 4354;
+        public UInt32 RGBA = 0x202020FF;
+
+        public UInt32[] UNUSED_UINT32 = new UInt32[2];
+
+        public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
+        {
+            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
+            Trace.Assert(this.UNUSED_UINT32[0] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[0]}) in reserve variable.");
+
+            rw.RwUInt32(ref this.Unk);
+
+            rw.RwUInt32(ref this.UNUSED_UINT32[1]);
+            Trace.Assert(this.UNUSED_UINT32[1] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[1]}) in reserve variable.");
+
+            rw.RwUInt32(ref this.RGBA);
+        }
+    }
+}

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/EnCc.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/EnCc.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using Serialization;
+
+namespace EVTUI;
+
+public partial class CommandTypes
+{
+    public class EnCc : ISerializable
+    {
+        public const int DataSize = 48;
+
+        public UInt32 Enable = 1;
+        public UInt32 Unk = 4354;
+
+        public float Cyan;
+        public float Magenta;
+        public float Yellow;
+        public float Dodge;
+        public float Burn;
+
+        public UInt32[] UNUSED_UINT32 = new UInt32[5];
+
+        public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
+        {
+            rw.RwUInt32(ref this.Enable);
+            rw.RwUInt32(ref this.Unk);
+
+            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
+            rw.RwUInt32(ref this.UNUSED_UINT32[1]);
+
+            rw.RwFloat32(ref this.Cyan);
+            rw.RwFloat32(ref this.Magenta);
+            rw.RwFloat32(ref this.Yellow);
+            rw.RwFloat32(ref this.Dodge);
+            rw.RwFloat32(ref this.Burn);
+
+            rw.RwUInt32(ref this.UNUSED_UINT32[2]);
+            rw.RwUInt32(ref this.UNUSED_UINT32[3]);
+            rw.RwUInt32(ref this.UNUSED_UINT32[4]);
+
+            for (int i=0; i<this.UNUSED_UINT32.Length; i++)
+                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
+        }
+    }
+}

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/EnDf.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/EnDf.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using Serialization;
+
+namespace EVTUI;
+
+public partial class CommandTypes
+{
+    public class EnDf : ISerializable
+    {
+        public const int DataSize = 48;
+
+        public UInt32 Unk1;
+        public UInt32 Unk2 = 4354;
+        public UInt32 Unk3;
+
+        public float FocalPlaneDistance;
+        public float NearBlurSurface;
+        public float FarBlurSurface;
+
+        public float DistanceBlurLimit;
+
+        public float BlurStrength = 1.0F;
+        public UInt32 BlurType;
+
+        public UInt32[] UNUSED_UINT32 = new UInt32[3];
+
+        public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
+        {
+            rw.RwUInt32(ref this.Unk1);
+            rw.RwUInt32(ref this.Unk2);
+            rw.RwUInt32(ref this.Unk3);
+
+            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
+            Trace.Assert(this.UNUSED_UINT32[0] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[0]}) in reserve variable.");
+
+            rw.RwFloat32(ref this.FocalPlaneDistance);
+            rw.RwFloat32(ref this.NearBlurSurface);
+            rw.RwFloat32(ref this.FarBlurSurface);
+
+            rw.RwFloat32(ref this.DistanceBlurLimit);
+
+            rw.RwFloat32(ref this.BlurStrength);
+            rw.RwUInt32(ref this.BlurType);
+
+            for (int i=1; i<this.UNUSED_UINT32.Length; i++)
+            {
+                rw.RwUInt32(ref this.UNUSED_UINT32[i]);
+                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
+            }
+        }
+    }
+}

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/EnFD.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/EnFD.cs
@@ -8,25 +8,35 @@ namespace EVTUI;
 
 public partial class CommandTypes
 {
-    public class FOD_ : ISerializable
+    public class EnFD : ISerializable
     {
-        public const int DataSize = 16;
+        public const int DataSize = 32;
 
-        public UInt32 EnableFieldObject;
-        public Int32 ObjectIndex;
+        public Bitfield32 Flags = new Bitfield32(65537);
+        public UInt32 Unk = 4354;
+
+        public UInt32 Mode;
+        public float StartDistance = 5;
+        public float EndDistance   = 2000;
+        public UInt32 RGBA         = 0x7F7F7F00;
 
         public UInt32[] UNUSED_UINT32 = new UInt32[2];
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
-            rw.RwUInt32(ref this.EnableFieldObject);
-            rw.RwInt32(ref this.ObjectIndex);
+            rw.RwObj(ref this.Flags);
+            rw.RwUInt32(ref this.Unk);
 
             for (int i=0; i<this.UNUSED_UINT32.Length; i++)
             {
                 rw.RwUInt32(ref this.UNUSED_UINT32[i]);
                 Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
             }
+
+            rw.RwUInt32(ref this.Mode);
+            rw.RwFloat32(ref this.StartDistance);
+            rw.RwFloat32(ref this.EndDistance);
+            rw.RwUInt32(ref this.RGBA);
         }
     }
 }

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/EnFH.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/EnFH.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using Serialization;
+
+namespace EVTUI;
+
+public partial class CommandTypes
+{
+    public class EnFH : ISerializable
+    {
+        public const int DataSize = 32;
+
+        public UInt32 Unk1 = 1;
+        public UInt32 Unk2 = 4354;
+
+        public float StartHeight = 5;
+        public float EndHeight   = 2000;
+        public UInt32 RGBA       = 0x7F7F7F00;
+
+        public UInt32[] UNUSED_UINT32 = new UInt32[3];
+
+        public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
+        {
+            rw.RwUInt32(ref this.Unk1);
+            rw.RwUInt32(ref this.Unk2);
+
+            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
+            rw.RwUInt32(ref this.UNUSED_UINT32[1]);
+
+            rw.RwFloat32(ref this.StartHeight);
+            rw.RwFloat32(ref this.EndHeight);
+            rw.RwUInt32(ref this.RGBA);
+
+            rw.RwUInt32(ref this.UNUSED_UINT32[2]);
+
+            for (int i=0; i<this.UNUSED_UINT32.Length; i++)
+                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
+
+        }
+    }
+}

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/EnHd.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/EnHd.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using Serialization;
+
+namespace EVTUI;
+
+public partial class CommandTypes
+{
+    public class EnHd : ISerializable
+    {
+        public const int DataSize = 80;
+
+        public Bitfield32 Flags = new Bitfield32();
+        public UInt32 Unk1 = 4354;
+
+        public float ToneMapMediumBrightness;
+        public float ToneMapBloomStrength = 0.3F;
+        public float ToneMapAdaptiveBrightness;
+        public float ToneMapAdaptiveBloom = 0.016666667F;
+
+        public UInt32 StarFilterNumberOfLines           = 4;
+        public float StarFilterLength                   = 1.0F;
+        public float StarFilterStrength                 = 0.5F;
+        public float StarFilterGlareChromaticAberration = 1.5F;
+        public float StarFilterGlareTilt                = 25.0F;
+
+        public float UnkFloat1 = 3.8F;
+        public float UnkFloat2 = 0.35F;
+        public float UnkFloat3 = 0.03F;
+
+        public UInt32 UnkEnum = 1;
+        public UInt32 RGBA1;
+        public UInt32 RGBA2;
+        public UInt32 RGBA3;
+
+        public UInt32[] UNUSED_UINT32 = new UInt32[2];
+
+        public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
+        {
+            rw.RwObj(ref this.Flags);
+            rw.RwUInt32(ref this.Unk1);
+
+            for (int i=0; i<this.UNUSED_UINT32.Length; i++)
+            {
+                rw.RwUInt32(ref this.UNUSED_UINT32[i]);
+                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
+            }
+
+            rw.RwFloat32(ref this.ToneMapMediumBrightness);
+            rw.RwFloat32(ref this.ToneMapBloomStrength);
+            rw.RwFloat32(ref this.ToneMapAdaptiveBrightness);
+            rw.RwFloat32(ref this.ToneMapAdaptiveBloom);
+
+            rw.RwUInt32(ref this.StarFilterNumberOfLines);
+            rw.RwFloat32(ref this.StarFilterLength);
+            rw.RwFloat32(ref this.StarFilterStrength);
+            rw.RwFloat32(ref this.StarFilterGlareChromaticAberration);
+            rw.RwFloat32(ref this.StarFilterGlareTilt);
+
+            rw.RwFloat32(ref this.UnkFloat1);
+            rw.RwFloat32(ref this.UnkFloat2);
+            rw.RwFloat32(ref this.UnkFloat3);
+
+            if ((int)args["dataSize"] > 64)
+            {
+                rw.RwUInt32(ref this.UnkEnum);
+                rw.RwUInt32(ref this.RGBA1);
+                rw.RwUInt32(ref this.RGBA2);
+                rw.RwUInt32(ref this.RGBA3);
+            }
+        }
+    }
+}

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/EnL0.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/EnL0.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using Serialization;
+
+namespace EVTUI;
+
+public partial class CommandTypes
+{
+    public class EnL0 : ISerializable
+    {
+        public const int DataSize = 48;
+
+        public UInt32 Unk1 = 1;
+        public UInt32 Unk2 = 4354;
+
+        public UInt32 AmbientRGBA = 0xBFBFBFFF;
+        public UInt32 DiffuseRGBA = 0xE5E5E5FF;
+        public UInt32 SpecularRGBA = 0xFFFFFFFF;
+
+        public float[] Direction = new float[] {0.0F, 0.5299989581108093F, 0.847998321056366F};
+
+        public UInt32[] UNUSED_UINT32 = new UInt32[4];
+
+        public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
+        {
+            rw.RwUInt32(ref this.Unk1);
+            Trace.Assert(this.Unk1 == 1, $"Unexpected value ({this.Unk2}) in constant field (expected value: 4354).");
+
+            rw.RwUInt32(ref this.Unk2);
+            Trace.Assert(this.Unk2 == 4354, $"Unexpected value ({this.Unk2}) in constant field (expected value: 4354).");
+
+            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
+            rw.RwUInt32(ref this.UNUSED_UINT32[1]);
+
+            rw.RwUInt32(ref this.AmbientRGBA);
+            rw.RwUInt32(ref this.DiffuseRGBA);
+            rw.RwUInt32(ref this.SpecularRGBA);
+
+            rw.RwFloat32s(ref this.Direction, 3);
+
+            rw.RwUInt32(ref this.UNUSED_UINT32[2]);
+            rw.RwUInt32(ref this.UNUSED_UINT32[3]);
+
+            for (int i=0; i<this.UNUSED_UINT32.Length; i++)
+                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
+        }
+    }
+}

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/EnLI.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/EnLI.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using Serialization;
+
+namespace EVTUI;
+
+public partial class CommandTypes
+{
+    public class EnLI : ISerializable
+    {
+        public const int DataSize = 48;
+
+        public UInt32 Unk1 = 1;
+        public UInt32 Unk2 = 4354;
+
+        public UInt32 AmbientRGBA = 0xBFBFBFFF;
+        public UInt32 DiffuseRGBA = 0xE5E5E5FF;
+        public UInt32 SpecularRGBA = 0xFFFFFFFF;
+
+        public float[] Direction = new float[] {0.0F, 0.5299989581108093F, 0.847998321056366F};
+
+        public UInt32[] UNUSED_UINT32 = new UInt32[4];
+
+        public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
+        {
+            rw.RwUInt32(ref this.Unk1);
+            Trace.Assert(this.Unk1 == 1, $"Unexpected value ({this.Unk2}) in constant field (expected value: 4354).");
+
+            rw.RwUInt32(ref this.Unk2);
+            Trace.Assert(this.Unk2 == 4354, $"Unexpected value ({this.Unk2}) in constant field (expected value: 4354).");
+
+            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
+            rw.RwUInt32(ref this.UNUSED_UINT32[1]);
+
+            rw.RwUInt32(ref this.AmbientRGBA);
+            rw.RwUInt32(ref this.DiffuseRGBA);
+            rw.RwUInt32(ref this.SpecularRGBA);
+
+            rw.RwFloat32s(ref this.Direction, 3);
+
+            rw.RwUInt32(ref this.UNUSED_UINT32[2]);
+            rw.RwUInt32(ref this.UNUSED_UINT32[3]);
+
+            for (int i=0; i<this.UNUSED_UINT32.Length; i++)
+                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
+        }
+    }
+}

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/EnOl.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/EnOl.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using Serialization;
+
+namespace EVTUI;
+
+public partial class CommandTypes
+{
+    public class EnOl : ISerializable
+    {
+        public const int DataSize = 32;
+
+        public UInt32 Unk1 = 1;
+        public UInt32 Unk2 = 4354;
+
+        public float Strength;
+        public float Width = 1.01F;
+        public float Brightness = 1.0F;
+        public float RangeMin = 100.0F;
+        public float RangeMax = 150.0F;
+
+        public UInt32[] UNUSED_UINT32 = new UInt32[1];
+
+        public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
+        {
+            rw.RwUInt32(ref this.Unk1);
+            Trace.Assert(this.Unk1 == 1, $"Unexpected value ({this.Unk2}) in constant field (expected value: 4354).");
+
+            rw.RwUInt32(ref this.Unk2);
+            Trace.Assert(this.Unk2 == 4354, $"Unexpected value ({this.Unk2}) in constant field (expected value: 4354).");
+
+            rw.RwFloat32(ref this.Strength);
+            rw.RwFloat32(ref this.Width);
+            rw.RwFloat32(ref this.Brightness);
+            rw.RwFloat32(ref this.RangeMin);
+            rw.RwFloat32(ref this.RangeMax);
+
+            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
+            Trace.Assert(this.UNUSED_UINT32[0] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[0]}) in reserve variable.");
+        }
+    }
+}

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/EnPh.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/EnPh.cs
@@ -8,19 +8,17 @@ namespace EVTUI;
 
 public partial class CommandTypes
 {
-    public class FOD_ : ISerializable
+    public class EnPh : ISerializable
     {
         public const int DataSize = 16;
 
-        public UInt32 EnableFieldObject;
-        public Int32 ObjectIndex;
+        public UInt32 Enable = 1;
 
-        public UInt32[] UNUSED_UINT32 = new UInt32[2];
+        public UInt32[] UNUSED_UINT32 = new UInt32[3];
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
-            rw.RwUInt32(ref this.EnableFieldObject);
-            rw.RwInt32(ref this.ObjectIndex);
+            rw.RwUInt32(ref this.Enable);
 
             for (int i=0; i<this.UNUSED_UINT32.Length; i++)
             {

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/EnSh.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/EnSh.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using Serialization;
+
+namespace EVTUI;
+
+public partial class CommandTypes
+{
+    public class EnSh : ISerializable
+    {
+        public const int DataSize = 48;
+
+        public UInt32 Unk = 4354;
+
+        public Bitfield32 Flags = new Bitfield32(6);
+
+        public float DepthRange = 2000.0F;
+        public float Bias;
+        public float Ambient = 1.0F;
+        public float Diffuse = 1.0F;
+        public float CascadedShadowMapPartitionInterval = 0.12F;
+
+        public UInt32[] UNUSED_UINT32 = new UInt32[5];
+
+        public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
+        {
+            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
+
+            rw.RwUInt32(ref this.Unk);
+            Trace.Assert(this.Unk == 4354, $"Unexpected value ({this.Unk}) in constant field (expected value: 4354).");
+
+            rw.RwUInt32(ref this.UNUSED_UINT32[1]);
+            rw.RwUInt32(ref this.UNUSED_UINT32[2]);
+
+            rw.RwObj(ref this.Flags);
+
+            rw.RwFloat32(ref this.DepthRange);
+            rw.RwFloat32(ref this.Bias);
+            rw.RwFloat32(ref this.Ambient);
+            rw.RwFloat32(ref this.Diffuse);
+            rw.RwFloat32(ref this.CascadedShadowMapPartitionInterval);
+
+            rw.RwUInt32(ref this.UNUSED_UINT32[3]);
+            rw.RwUInt32(ref this.UNUSED_UINT32[4]);
+
+            for (int i=0; i<this.UNUSED_UINT32.Length; i++)
+                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
+        }
+    }
+}

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/EnSs.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/EnSs.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using Serialization;
+
+namespace EVTUI;
+
+public partial class CommandTypes
+{
+    public class EnSs : ISerializable
+    {
+        public const int DataSize = 48;
+
+        public UInt32 Enable;
+        public UInt32 Unk = 4354;
+
+        public float Range = 545.0F;
+        public float Radius = 1.15F;
+        public float Attenuation = 0.45F;
+        public float Concentration = 1.0F;
+        public float Blur = 1.5F;
+
+        public UInt32[] UNUSED_UINT32 = new UInt32[5];
+
+        public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
+        {
+            rw.RwUInt32(ref this.Enable);
+            rw.RwUInt32(ref this.Unk);
+            Trace.Assert(this.Unk == 4354, $"Unexpected value ({this.Unk}) in constant field (expected value: 4354).");
+
+            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
+            rw.RwUInt32(ref this.UNUSED_UINT32[1]);
+
+            rw.RwFloat32(ref this.Range);
+            rw.RwFloat32(ref this.Radius);
+            rw.RwFloat32(ref this.Attenuation);
+            rw.RwFloat32(ref this.Concentration);
+            rw.RwFloat32(ref this.Blur);
+
+            rw.RwUInt32(ref this.UNUSED_UINT32[2]);
+            rw.RwUInt32(ref this.UNUSED_UINT32[3]);
+            rw.RwUInt32(ref this.UNUSED_UINT32[4]);
+
+            for (int i=0; i<this.UNUSED_UINT32.Length; i++)
+                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
+        }
+    }
+}

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/Env_.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/Env_.cs
@@ -8,25 +8,25 @@ namespace EVTUI;
 
 public partial class CommandTypes
 {
-    public class FOD_ : ISerializable
+    public class Env_ : ISerializable
     {
         public const int DataSize = 16;
 
-        public UInt32 EnableFieldObject;
-        public Int32 ObjectIndex;
+        public Int32 ObjectId;
 
-        public UInt32[] UNUSED_UINT32 = new UInt32[2];
+        public UInt32[] UNUSED_UINT32 = new UInt32[3];
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
-            rw.RwUInt32(ref this.EnableFieldObject);
-            rw.RwInt32(ref this.ObjectIndex);
+            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
+
+            rw.RwInt32(ref this.ObjectId);
+
+            rw.RwUInt32(ref this.UNUSED_UINT32[1]);
+            rw.RwUInt32(ref this.UNUSED_UINT32[2]);
 
             for (int i=0; i<this.UNUSED_UINT32.Length; i++)
-            {
-                rw.RwUInt32(ref this.UNUSED_UINT32[i]);
                 Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
-            }
         }
     }
 }


### PR DESCRIPTION
New commands include:

- EnBc
- EnCc
- EnDf
- EnFD
- EnFH
- EnHd
- EnL0
- EnLI
- EnOl
- EnPh
- EnSh
- EnSs
- Env_

Also moved unit vector methods into FieldUtils so they can be shared by `ML__`, `EnL0`, and `EnLI`.