### PR TITLE
Quick fix for zero-element turns in BMD scripts

### DIFF
--- a/src/lib/FileIO/Formats/BMD.cs
+++ b/src/lib/FileIO/Formats/BMD.cs
@@ -216,7 +216,10 @@ public class Turn : ISerializable
             }
         }
         else
+        {
+            this.Elems = new byte[0][];
             this.TextBufferSize = 0;
+        }
     }
 
 }


### PR DESCRIPTION
Events like `E707_020` break because some dialogue turns in the BMD are empty (e.g., `MSG_902_0_0`, `MSG_900_0_0`, `MSG_901_0_0`), and the ScriptManager was checking for the length of the relevant 2D array. This fixes that by actually initializing the array to have length zero, where before it was `null` in such a case.