### PR TITLE
Add setup for Fedora-based Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ The command prompt and similar interfaces should work with this syntax:
 ./scripts/bootstrap_debian.sh
 ```
 
+### Fedora-based Linux
+
+```
+./scripts/bootstrap_fedora.sh
+```
+
+(Credit to [theloneraven](https://github.com/theloneraven) for getting this setup working.)
+
 ### Other Linux
 
 TBD.

--- a/scripts/bootstrap_fedora.sh
+++ b/scripts/bootstrap_fedora.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# make sure submodules are set up
+git submodule update --init --recursive
+
+# apply patches to submodules
+./scripts/apply_patches.sh
+
+# install other dependencies
+sudo dnf install vlc-devel vlc
+
+# uncomment or run these separately if still having issues with sounds
+#sudo dnf install gtk-sharp2
+#sudo dnf install libX11-devel


### PR DESCRIPTION
## In this PR:

- A new `bootstrap_fedora.sh` script for getting the app set up on Fedora-based distros.
- An update to the README pointing to the new script!

## For future PRs:

- Setup for any other Linux distros not covered under the Debian or Fedora umbrellas, probably.