### PR TITLE
Initial logging implementation

### DIFF
--- a/src/gui/ConfigWindow/ConfigurationPanel/ConfigurationPanel.axaml.cs
+++ b/src/gui/ConfigWindow/ConfigurationPanel/ConfigurationPanel.axaml.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 
 using ReactiveUI;
 using Avalonia.Controls;
+using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.ReactiveUI;
 
@@ -133,20 +134,28 @@ public partial class ConfigurationPanel : ReactiveUserControl<ConfigurationPanel
 
     public async void UseSelectedEvent(object sender, RoutedEventArgs e)
     {
+        this.topLevel.Cursor = new Cursor(StandardCursorType.Wait);
         var retTuple = ViewModel!.TryLoadEvent(true);
         if (retTuple.Status == 0)
             this.topLevel.Close(0);
         else
+        {
+            this.topLevel.Cursor = Cursor.Default;
             await Utils.RaiseModal(this.topLevel, retTuple.Message);
+        }
     }
 
     public async void UseEnteredEvent(object sender, RoutedEventArgs e)
     {
+        this.topLevel.Cursor = new Cursor(StandardCursorType.Wait);
         var retTuple = ViewModel!.TryLoadEvent(false);
         if (retTuple.Status == 0)
             this.topLevel.Close(0);
         else
+        {
+            this.topLevel.Cursor = Cursor.Default;
             await Utils.RaiseModal(this.topLevel, retTuple.Message);
+        }
     }
 
 }

--- a/src/gui/ConfigWindow/ConfigurationPanel/ConfigurationPanelViewModel.cs
+++ b/src/gui/ConfigWindow/ConfigurationPanel/ConfigurationPanelViewModel.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 
@@ -445,12 +446,14 @@ public class ConfigurationPanelViewModel : ViewModelBase
             else if (!this.Config.EventLoaded)
                 return (1, $"Event E{this.EventMajorId:000}_{this.EventMinorId:000} does not exist and could not be loaded.");
         }
-        catch (IOException)
+        catch (IOException ex)
         {
+            Trace.TraceError(ex.ToString());
             return (1, "Failed to load event because the game files are in use.\nIf the game is currently open, close it before trying again.");
         }
         catch (Exception ex)
         {
+            Trace.TraceError(ex.ToString());
             return (1, "Failed to extract EVT due to unhandled exception: '" + ex.ToString() + "'");
         }
 

--- a/src/gui/EditorWindow/EditorWindow.axaml.cs
+++ b/src/gui/EditorWindow/EditorWindow.axaml.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.IO;
 
 using Avalonia;
@@ -25,12 +26,14 @@ public partial class EditorWindow : Window
             ((EditorWindowViewModel)DataContext).SaveMod(((MenuItem)sender).Name);
             await Utils.RaiseModal(this, "Saved successfully!");
         }
-        catch (IOException)
+        catch (IOException ex)
         {
+            Trace.TraceError(ex.ToString());
             await Utils.RaiseModal(this, "Failed to save because the game files are in use.\nIf the game is currently open, close it before trying again.");
         }
         catch (Exception ex)
         {
+            Trace.TraceError(ex.ToString());
             await Utils.RaiseModal(this, "Failed to save due to unhandled exception: '" + ex.ToString() + "'");
         }
     }

--- a/src/gui/EditorWindow/TimelinePanel/TimelinePanel.axaml
+++ b/src/gui/EditorWindow/TimelinePanel/TimelinePanel.axaml
@@ -1796,7 +1796,7 @@
                     </ItemsPanelTemplate>
                   </ItemsControl.ItemsPanel>
                   <ItemsControl.Styles>
-                    <Style Selector="ContentPresenter"> <!--x:DataType="vm:CommandPointer"-->
+                    <Style Selector="ItemsControl > ContentPresenter" x:DataType="vm:CommandPointer">
                       <Setter Property="Canvas.Left" Value="{c:Binding 85*Frame + 10}"/>
                     </Style>
                     <Style Selector="ItemsControl.show > ContentPresenter">

--- a/src/gui/Program.cs
+++ b/src/gui/Program.cs
@@ -1,7 +1,9 @@
 ﻿using Avalonia;
 using Avalonia.ReactiveUI;
+
 using System;
 using System.Collections.ObjectModel;
+using System.IO;
 using System.Threading;
 
 namespace EVTUI;
@@ -11,15 +13,21 @@ sealed class Program
     private static string AppName = "Global\\EVTUI";
     private static Mutex AppMutex = new Mutex(initiallyOwned: true, AppName);
 
+    private static string LocalDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "EVTUI");
+
     // Initialization code. Don't use any Avalonia, third-party APIs or any
     // SynchronizationContext-reliant code before AppMain is called: things aren't initialized
     // yet and stuff might break.
     [STAThread]
     public static void Main(string[] args)
     {
+        if (!Directory.Exists(LocalDir))
+            Directory.CreateDirectory(LocalDir);
+
         if (AppMutex.WaitOne(TimeSpan.Zero, true))
             BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
         else
+            // I'd put this in the trace, but there's no listener 'til later in the process, so...
             Console.WriteLine("EVTUI instance already open.");
     }
 

--- a/src/lib/DataManager.cs
+++ b/src/lib/DataManager.cs
@@ -93,8 +93,6 @@ public class DataManager
         this.WorkingPath = Path.Combine(this.WorkingPathBase, Hashify(this.CpkPath));
         if (!Directory.Exists(this.WorkingPath))
             Directory.CreateDirectory(this.WorkingPath);
-
-        Console.WriteLine("#######################################");
     }
 
     public bool LoadEvent(int majorId, int minorId)

--- a/src/lib/EventManager.cs
+++ b/src/lib/EventManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Text.RegularExpressions;
 
@@ -217,7 +218,7 @@ public class EventManager
                 pattern = $"MODEL[\\\\/]FIELD_TEX[\\\\/]F{obj.ResourceMajorId:000}_{obj.ResourceMinorId:000}_{obj.ResourceSubId}\\.GFS";
                 break;
             default:
-                Console.WriteLine(obj.Type);
+                Trace.TraceWarning($"Unknown asset type: {obj.Type}");
                 break;
         }
         if (pattern == "")

--- a/src/lib/FileIO/CPKExtract.cs
+++ b/src/lib/FileIO/CPKExtract.cs
@@ -6,6 +6,7 @@ using CriFsV2Lib.Definitions.Utilities;
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -180,13 +181,13 @@ public static class CPKExtract
                 retval.awbPaths.Add(candidatePath);
             else
                 return false;
-            Console.WriteLine(candidatePath);
+            Trace.TraceInformation($"Found file path to load: {candidatePath}");
             return true;
         }
 
         Parallel.ForEach(CpkList, CpkPath =>
         {
-            Console.WriteLine(CpkPath);
+            Trace.TraceInformation($"Loading from CPK: {CpkPath}");
             CpkFile[] files;
             using (var fileStream = new FileStream(CpkPath, FileMode.Open))
             using (var reader = CriFsLib.Instance.CreateCpkReader(fileStream, true, decryptionFunction))

--- a/src/lib/FileIO/Formats/BMD.cs
+++ b/src/lib/FileIO/Formats/BMD.cs
@@ -19,7 +19,7 @@ public class BMD : ISerializable
     public UInt32 FileSize;
 
     public string Endianness;
-    public string Magic;
+    public MagicString Magic = new MagicString(BMD.MAGIC);
 
     public UInt32 ExtSize;
     public UInt32 RelocationTableOffset;
@@ -46,6 +46,11 @@ public class BMD : ISerializable
 
     public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
     {
+        if (rw.IsConstructlike())
+            Trace.TraceInformation("Reading BMD object");
+        else if (rw.IsParselike())
+            Trace.TraceInformation("Writing BMD object");
+
         rw.RwUInt8(ref this.FileType);
         rw.RwUInt8(ref this.Format);
         rw.RwUInt16(ref this.UserId);
@@ -56,8 +61,7 @@ public class BMD : ISerializable
         if (this.Endianness == "0")
             rw.SetLittleEndian(true);
 
-        rw.RwString(ref this.Magic, 3, Encoding.ASCII);
-        Trace.Assert(this.Magic == BMD.MAGIC, $"Magic string ({this.Magic}) doesn't match expected string ({BMD.MAGIC})");
+        rw.RwObj(ref this.Magic);
 
         rw.RwUInt32(ref this.ExtSize);
         rw.RwUInt32(ref this.RelocationTableOffset);

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/CAA_.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/CAA_.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Linq;
 
 using Serialization;
 
@@ -17,20 +17,24 @@ public partial class CommandTypes
         public UInt32 AnimationId;
         public float PlaybackSpeed = 1.0F;
 
-        public UInt32[] UNUSED_UINT32 = new UInt32[8];
+        public ConstUInt32[] UNUSED_UINT32 = Enumerable.Range(0, 8).Select(i => new ConstUInt32()).ToArray();
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
             rw.RwObj(ref this.Flags);
+
             rw.RwInt32(ref this.AssetId);
             rw.RwUInt32(ref this.AnimationId);
             rw.RwFloat32(ref this.PlaybackSpeed);
 
-            for (int i=0; i<this.UNUSED_UINT32.Length; i++)
-            {
-                rw.RwUInt32(ref this.UNUSED_UINT32[i]);
-                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
-            }
+            rw.RwObj(ref this.UNUSED_UINT32[0], args);
+            rw.RwObj(ref this.UNUSED_UINT32[1], args);
+            rw.RwObj(ref this.UNUSED_UINT32[2], args);
+            rw.RwObj(ref this.UNUSED_UINT32[3], args);
+            rw.RwObj(ref this.UNUSED_UINT32[4], args);
+            rw.RwObj(ref this.UNUSED_UINT32[5], args);
+            rw.RwObj(ref this.UNUSED_UINT32[6], args);
+            rw.RwObj(ref this.UNUSED_UINT32[7], args);
         }
     }
 }

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/CAR_.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/CAR_.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Linq;
 
 using Serialization;
 
@@ -14,17 +14,15 @@ public partial class CommandTypes
 
         public Bitfield32 Flags = new Bitfield32(3);
 
-        public UInt32[] UNUSED_UINT32 = new UInt32[3];
+        public ConstUInt32[] UNUSED_UINT32 = Enumerable.Range(0, 3).Select(i => new ConstUInt32()).ToArray();
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
             rw.RwObj(ref this.Flags);
 
-            for (int i=0; i<this.UNUSED_UINT32.Length; i++)
-            {
-                rw.RwUInt32(ref this.UNUSED_UINT32[i]);
-                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
-            }
+            rw.RwObj(ref this.UNUSED_UINT32[0], args);
+            rw.RwObj(ref this.UNUSED_UINT32[1], args);
+            rw.RwObj(ref this.UNUSED_UINT32[2], args);
         }
     }
 }

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/CClp.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/CClp.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Linq;
 
 using Serialization;
 
@@ -15,15 +15,12 @@ public partial class CommandTypes
         public float NearClip = 1.0F;
         public float FarClip  = 60000.0F;
 
-        public UInt32[] UNUSED_UINT32 = new UInt32[2];
+        public ConstUInt32[] UNUSED_UINT32 = Enumerable.Range(0, 2).Select(i => new ConstUInt32()).ToArray();
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
-            for (int i=0; i<this.UNUSED_UINT32.Length; i++)
-            {
-                rw.RwUInt32(ref this.UNUSED_UINT32[i]);
-                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
-            }
+            rw.RwObj(ref this.UNUSED_UINT32[0], args);
+            rw.RwObj(ref this.UNUSED_UINT32[1], args);
 
             rw.RwFloat32(ref this.NearClip);
             rw.RwFloat32(ref this.FarClip);

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/CMC_.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/CMC_.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Linq;
 
 using Serialization;
 
@@ -29,8 +29,8 @@ public partial class CommandTypes
         public UInt32 MessageCoordinateType = 4;
         public float[] MessageCoordinates = new[] { 375.0F, 528.0F };
 
-        public UInt16[] UNUSED_UINT16 = new UInt16[1];
-        public UInt32[] UNUSED_UINT32 = new UInt32[2];
+        public ConstUInt16 UNUSED_UINT16 = new ConstUInt16();
+        public ConstUInt32[] UNUSED_UINT32 = Enumerable.Range(0, 2).Select(i => new ConstUInt32()).ToArray();
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
@@ -39,15 +39,13 @@ public partial class CommandTypes
             rw.RwUInt32(ref this.InterpolationParameters);
             rw.RwUInt16(ref this.StartCorrectionFrameNumber);
 
-            rw.RwUInt16(ref this.UNUSED_UINT16[0]);
-            Trace.Assert(this.UNUSED_UINT16[0] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT16[0]}) in reserve variable.");
-
-            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
+            rw.RwObj(ref this.UNUSED_UINT16, args);
+            rw.RwObj(ref this.UNUSED_UINT32[0], args);
 
             rw.RwInt32(ref this.AssetId);
             rw.RwUInt32(ref this.ShotType);
 
-            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
+            rw.RwObj(ref this.UNUSED_UINT32[1], args);
 
             rw.RwUInt32(ref this.AngleType);
 
@@ -62,9 +60,6 @@ public partial class CommandTypes
                 rw.RwUInt32(ref this.MessageCoordinateType);
                 rw.RwFloat32s(ref this.MessageCoordinates, 2);
             }
-
-            for (int i=0; i<this.UNUSED_UINT32.Length; i++)
-                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
         }
     }
 }

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/CMCn.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/CMCn.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Linq;
 
 using Serialization;
 
@@ -15,18 +15,16 @@ public partial class CommandTypes
         public UInt32 DirectionType;
         public float Distance;
 
-        public UInt32[] UNUSED_UINT32 = new UInt32[2];
+        public ConstUInt32[] UNUSED_UINT32 = Enumerable.Range(0, 2).Select(i => new ConstUInt32()).ToArray();
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
-            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
-            Trace.Assert(this.UNUSED_UINT32[0] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[0]}) in reserve variable.");
+            rw.RwObj(ref this.UNUSED_UINT32[0], args);
 
             rw.RwUInt32(ref this.DirectionType);
             rw.RwFloat32(ref this.Distance);
 
-            rw.RwUInt32(ref this.UNUSED_UINT32[1]);
-            Trace.Assert(this.UNUSED_UINT32[1] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[1]}) in reserve variable.");
+            rw.RwObj(ref this.UNUSED_UINT32[1], args);
         }
     }
 }

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/CMD_.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/CMD_.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Linq;
 
 using Serialization;
 
@@ -27,7 +27,7 @@ public partial class CommandTypes
         public float BlurStrength = 1.0F;
         public UInt32 BlurType;
 
-        public UInt32[] UNUSED_UINT32 = new UInt32[2];
+        public ConstUInt32[] UNUSED_UINT32 = Enumerable.Range(0, 2).Select(i => new ConstUInt32()).ToArray();
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
@@ -48,11 +48,8 @@ public partial class CommandTypes
                 rw.RwFloat32(ref this.BlurStrength);
                 rw.RwUInt32(ref this.BlurType);
 
-                for (int i=0; i<this.UNUSED_UINT32.Length; i++)
-                {
-                    rw.RwUInt32(ref this.UNUSED_UINT32[i]);
-                    Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
-                }
+                rw.RwObj(ref this.UNUSED_UINT32[0], args);
+                rw.RwObj(ref this.UNUSED_UINT32[1], args);
             }
         }
     }

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/CQuk.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/CQuk.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Linq;
 
 using Serialization;
 
@@ -17,23 +17,20 @@ public partial class CommandTypes
 		public UInt32 FadeInFrames;
 		public UInt32 FadeOutFrames;
 
-        public UInt32[] UNUSED_UINT32 = new UInt32[4];
+        public ConstUInt32[] UNUSED_UINT32 = Enumerable.Range(0, 4).Select(i => new ConstUInt32()).ToArray();
 
 		public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
 		{
-            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
-            Trace.Assert(this.UNUSED_UINT32[0] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[0]}) in reserve variable.");
+            rw.RwObj(ref this.UNUSED_UINT32[0], args);
 
 			rw.RwFloat32(ref this.StrengthOfShaking);
 			rw.RwFloat32(ref this.DegreeOfPitch);
 			rw.RwUInt32(ref this.FadeInFrames);
 			rw.RwUInt32(ref this.FadeOutFrames);
 
-            for (int i=1; i<this.UNUSED_UINT32.Length; i++)
-            {
-                rw.RwUInt32(ref this.UNUSED_UINT32[i]);
-                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
-            }
+            rw.RwObj(ref this.UNUSED_UINT32[1], args);
+            rw.RwObj(ref this.UNUSED_UINT32[2], args);
+            rw.RwObj(ref this.UNUSED_UINT32[3], args);
 		}
 	}
 }

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/CSA_.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/CSA_.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Linq;
 
 using Serialization;
 
@@ -35,8 +35,8 @@ public partial class CommandTypes
         public byte UnkEnum;
         public byte UnkInd = 2;
 
-        public UInt16[] UNUSED_UINT16 = new UInt16[1];
-        public UInt32[] UNUSED_UINT32 = new UInt32[4];
+        public ConstUInt16 UNUSED_UINT16 = new ConstUInt16();
+        public ConstUInt32[] UNUSED_UINT32 = Enumerable.Range(0, 4).Select(i => new ConstUInt32()).ToArray();
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
@@ -50,8 +50,7 @@ public partial class CommandTypes
             rw.RwFloat32s(ref this.ViewportCoordinates, 3);
             rw.RwFloat32s(ref this.ViewportRotation, 3);
 
-            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
-            Trace.Assert(this.UNUSED_UINT32[0] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[0]}) in reserve variable.");
+            rw.RwObj(ref this.UNUSED_UINT32[0], args);
 
             if ((int)args["dataSize"] > 48)
             {
@@ -70,14 +69,10 @@ public partial class CommandTypes
                     rw.RwUInt8(ref this.UnkEnum);
                     rw.RwUInt8(ref this.UnkInd);
 
-                    rw.RwUInt16(ref this.UNUSED_UINT16[0]);
-                    Trace.Assert(this.UNUSED_UINT16[0] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT16[0]}) in reserve variable.");
-
-                    for (int i=1; i<this.UNUSED_UINT32.Length; i++)
-                    {
-                        rw.RwUInt32(ref this.UNUSED_UINT32[i]);
-                        Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
-                    }
+                    rw.RwObj(ref this.UNUSED_UINT16, args);
+                    rw.RwObj(ref this.UNUSED_UINT32[1], args);
+                    rw.RwObj(ref this.UNUSED_UINT32[2], args);
+                    rw.RwObj(ref this.UNUSED_UINT32[3], args);
                 }
             }
         }

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/CSDD.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/CSDD.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 
 using Serialization;
 

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/CSD_.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/CSD_.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 
 using Serialization;
 

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/CSEc.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/CSEc.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Linq;
 
 using Serialization;
 
@@ -22,8 +22,8 @@ public partial class CommandTypes
 		public byte UnkBool;
 		public byte UnkEnum;
 
-        public UInt16[] UNUSED_UINT16 = new UInt16[1];
-        public UInt32[] UNUSED_UINT32 = new UInt32[2];
+        public ConstUInt16 UNUSED_UINT16 = new ConstUInt16();
+        public ConstUInt32[] UNUSED_UINT32 = Enumerable.Range(0, 2).Select(i => new ConstUInt32()).ToArray();
 
 		public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
 		{
@@ -31,11 +31,8 @@ public partial class CommandTypes
 
 			rw.RwInt32(ref this.AssetId);
 
-            for (int i=0; i<this.UNUSED_UINT32.Length; i++)
-            {
-                rw.RwUInt32(ref this.UNUSED_UINT32[i]);
-                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
-            }
+			rw.RwObj(ref this.UNUSED_UINT32[0], args);
+			rw.RwObj(ref this.UNUSED_UINT32[1], args);
 
 			rw.RwUInt32(ref this.MessageCoordinateType);
 			rw.RwFloat32s(ref this.MessageCoordinates, 2);
@@ -43,8 +40,7 @@ public partial class CommandTypes
 			rw.RwUInt8(ref this.UnkBool);
 			rw.RwUInt8(ref this.UnkEnum);
 
-            rw.RwUInt16(ref this.UNUSED_UINT16[0]);
-            Trace.Assert(this.UNUSED_UINT16[0] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT16[0]}) in reserve variable.");
+            rw.RwObj(ref this.UNUSED_UINT16, args);
 		}
 	}
 }

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/CShk.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/CShk.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Linq;
 
 using Serialization;
 
@@ -18,12 +18,11 @@ public partial class CommandTypes
         public float Magnitude = 1.0F;
         public float Speed     = 1.0F;
 
-        public UInt32[] UNUSED_UINT32 = new UInt32[4];
+        public ConstUInt32[] UNUSED_UINT32 = Enumerable.Range(0, 4).Select(i => new ConstUInt32()).ToArray();
 
 		public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
 		{
-            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
-            Trace.Assert(this.UNUSED_UINT32[0] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[0]}) in reserve variable.");
+            rw.RwObj(ref this.UNUSED_UINT32[0], args);
 
 			rw.RwUInt32(ref this.Action);
 			rw.RwUInt32(ref this.ShakingType);
@@ -31,11 +30,9 @@ public partial class CommandTypes
 			rw.RwFloat32(ref this.Magnitude);
 			rw.RwFloat32(ref this.Speed);
 
-            for (int i=1; i<this.UNUSED_UINT32.Length; i++)
-            {
-                rw.RwUInt32(ref this.UNUSED_UINT32[i]);
-                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
-            }
+            rw.RwObj(ref this.UNUSED_UINT32[1], args);
+            rw.RwObj(ref this.UNUSED_UINT32[2], args);
+            rw.RwObj(ref this.UNUSED_UINT32[3], args);
 		}
 	}
 }

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/CSk_.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/CSk_.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Linq;
 
 using Serialization;
 
@@ -14,20 +14,16 @@ public partial class CommandTypes
 
         public UInt32 VibrationMode;
 
-        public UInt32[] UNUSED_UINT32 = new UInt32[4];
+        public ConstUInt32[] UNUSED_UINT32 = Enumerable.Range(0, 3).Select(i => new ConstUInt32()).ToArray();
 
 		public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
 		{
-            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
-            Trace.Assert(this.UNUSED_UINT32[0] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[0]}) in reserve variable.");
+            rw.RwObj(ref this.UNUSED_UINT32[0], args);
 
 			rw.RwUInt32(ref this.VibrationMode);
 
-            for (int i=1; i<this.UNUSED_UINT32.Length; i++)
-            {
-                rw.RwUInt32(ref this.UNUSED_UINT32[i]);
-                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
-            }
+            rw.RwObj(ref this.UNUSED_UINT32[1], args);
+            rw.RwObj(ref this.UNUSED_UINT32[2], args);
 		}
 	}
 }

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/EAlp.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/EAlp.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Linq;
 
 using Serialization;
 
@@ -15,18 +15,16 @@ public partial class CommandTypes
         public byte[] RGBA = new byte[] {0, 0, 0, 255};
         public UInt32 InterpolationParameters = 4354;
 
-        public UInt32[] UNUSED_UINT32 = new UInt32[2];
+        public ConstUInt32[] UNUSED_UINT32 = Enumerable.Range(0, 2).Select(i => new ConstUInt32()).ToArray();
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
-            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
-            Trace.Assert(this.UNUSED_UINT32[0] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[0]}) in reserve variable.");
+            rw.RwObj(ref this.UNUSED_UINT32[0], args);
 
             rw.RwUInt8s(ref this.RGBA, 4);
             rw.RwUInt32(ref this.InterpolationParameters);
 
-            rw.RwUInt32(ref this.UNUSED_UINT32[1]);
-            Trace.Assert(this.UNUSED_UINT32[1] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[1]}) in reserve variable.");
+            rw.RwObj(ref this.UNUSED_UINT32[1], args);
         }
     }
 }

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/ELd_.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/ELd_.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Linq;
 
 using Serialization;
 
@@ -12,13 +12,11 @@ public partial class CommandTypes
     {
         public const int DataSize = 16;
 
-        public UInt32[] UNUSED_UINT32 = new UInt32[8];
+        public ConstUInt32[] UNUSED_UINT32 = Enumerable.Range(0, 4).Select(i => new ConstUInt32()).ToArray();
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
-            rw.RwUInt32s(ref this.UNUSED_UINT32, 4);
-            for (int i=0; i<this.UNUSED_UINT32.Length; i++)
-                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
+            rw.RwObjs(ref this.UNUSED_UINT32, 4, args);
         }
     }
 }

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/EMD_.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/EMD_.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Linq;
 
 using Serialization;
 
@@ -19,7 +19,7 @@ public partial class CommandTypes
         public float MovementSpeed = 1.0F;
         public UInt32 UNK;
 
-        public UInt32[] UNUSED_UINT32 = new UInt32[4];
+        public ConstUInt32[] UNUSED_UINT32 = Enumerable.Range(0, 4).Select(i => new ConstUInt32()).ToArray();
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
@@ -30,17 +30,14 @@ public partial class CommandTypes
                 for (int j=0; j<3; j++)
                     rw.RwFloat32(ref this.Targets[i,j]);
 
-            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
-            Trace.Assert(this.UNUSED_UINT32[0] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[0]}) in reserve variable.");
+            rw.RwObj(ref this.UNUSED_UINT32[0], args);
 
             rw.RwFloat32(ref this.MovementSpeed);
             rw.RwUInt32(ref this.UNK);
 
-            for (int i=1; i<this.UNUSED_UINT32.Length; i++)
-            {
-                rw.RwUInt32(ref this.UNUSED_UINT32[i]);
-                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
-            }
+            rw.RwObj(ref this.UNUSED_UINT32[1], args);
+            rw.RwObj(ref this.UNUSED_UINT32[2], args);
+            rw.RwObj(ref this.UNUSED_UINT32[3], args);
         }
     }
 }

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/ERgs.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/ERgs.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Linq;
 
 using Serialization;
 
@@ -15,17 +15,16 @@ public partial class CommandTypes
         public UInt32 DisplayType;
         public UInt32 Scene;
 
-        public UInt32[] UNUSED_UINT32 = new UInt32[2];
+        public ConstUInt32[] UNUSED_UINT32 = Enumerable.Range(0, 2).Select(i => new ConstUInt32()).ToArray();
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
-            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
+            rw.RwObj(ref this.UNUSED_UINT32[0], args);
+
             rw.RwUInt32(ref this.DisplayType);
             rw.RwUInt32(ref this.Scene);
-            rw.RwUInt32(ref this.UNUSED_UINT32[1]);
 
-            for (int i=0; i<this.UNUSED_UINT32.Length; i++)
-                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in MAt_ reserve variable.");
+            rw.RwObj(ref this.UNUSED_UINT32[1], args);
         }
     }
 }

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/ESD_.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/ESD_.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Linq;
 
 using Serialization;
 
@@ -15,18 +15,16 @@ public partial class CommandTypes
         public float[] Position = new float[3];
         public float[] Rotation = new float[3];
 
-        public UInt32[] UNUSED_UINT32 = new UInt32[2];
+        public ConstUInt32[] UNUSED_UINT32 = Enumerable.Range(0, 2).Select(i => new ConstUInt32()).ToArray();
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
-            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
-            Trace.Assert(this.UNUSED_UINT32[0] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[0]}) in reserve variable.");
+            rw.RwObj(ref this.UNUSED_UINT32[0], args);
 
             rw.RwFloat32s(ref this.Position, 3);
             rw.RwFloat32s(ref this.Rotation, 3);
 
-            rw.RwUInt32(ref this.UNUSED_UINT32[1]);
-            Trace.Assert(this.UNUSED_UINT32[1] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[1]}) in reserve variable.");
+            rw.RwObj(ref this.UNUSED_UINT32[1], args);
         }
     }
 }

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/ESH_.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/ESH_.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Linq;
 
 using Serialization;
 
@@ -23,7 +23,7 @@ public partial class CommandTypes
         public Int32 ModelObjectId;
         public UInt32 HelperId;
 
-        public UInt32[] UNUSED_UINT32 = new UInt32[2];
+        public ConstUInt32[] UNUSED_UINT32 = Enumerable.Range(0, 2).Select(i => new ConstUInt32()).ToArray();
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
@@ -38,11 +38,8 @@ public partial class CommandTypes
             rw.RwInt32(ref this.ModelObjectId);
             rw.RwUInt32(ref this.HelperId);
 
-            for (int i=0; i<this.UNUSED_UINT32.Length; i++)
-            {
-                rw.RwUInt32(ref this.UNUSED_UINT32[i]);
-                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[1]}) in reserve variable.");
-            }
+            rw.RwObj(ref this.UNUSED_UINT32[0], args);
+            rw.RwObj(ref this.UNUSED_UINT32[1], args);
         }
     }
 }

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/EScl.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/EScl.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Linq;
 
 using Serialization;
 
@@ -15,19 +15,16 @@ public partial class CommandTypes
         public UInt32 InterpolationParameters = 4354;
         public float Scale = 1;
 
-        public UInt32[] UNUSED_UINT32 = new UInt32[2];
+        public ConstUInt32[] UNUSED_UINT32 = Enumerable.Range(0, 2).Select(i => new ConstUInt32()).ToArray();
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
-            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
+            rw.RwObj(ref this.UNUSED_UINT32[0], args);
 
             rw.RwUInt32(ref this.InterpolationParameters);
             rw.RwFloat32(ref this.Scale);
 
-            rw.RwUInt32(ref this.UNUSED_UINT32[1]);
-
-            for (int i=0; i<this.UNUSED_UINT32.Length; i++)
-                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
+            rw.RwObj(ref this.UNUSED_UINT32[1], args);
         }
     }
 }

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/EnBc.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/EnBc.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Linq;
 
 using Serialization;
 
@@ -15,17 +15,15 @@ public partial class CommandTypes
         public UInt32 Unk = 4354;
         public UInt32 RGBA = 0x202020FF;
 
-        public UInt32[] UNUSED_UINT32 = new UInt32[2];
+        public ConstUInt32[] UNUSED_UINT32 = Enumerable.Range(0, 2).Select(i => new ConstUInt32()).ToArray();
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
-            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
-            Trace.Assert(this.UNUSED_UINT32[0] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[0]}) in reserve variable.");
+            rw.RwObj(ref this.UNUSED_UINT32[0], args);
 
             rw.RwUInt32(ref this.Unk);
 
-            rw.RwUInt32(ref this.UNUSED_UINT32[1]);
-            Trace.Assert(this.UNUSED_UINT32[1] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[1]}) in reserve variable.");
+            rw.RwObj(ref this.UNUSED_UINT32[1], args);
 
             rw.RwUInt32(ref this.RGBA);
         }

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/EnCc.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/EnCc.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Linq;
 
 using Serialization;
 
@@ -21,15 +21,15 @@ public partial class CommandTypes
         public float Dodge;
         public float Burn;
 
-        public UInt32[] UNUSED_UINT32 = new UInt32[5];
+        public ConstUInt32[] UNUSED_UINT32 = Enumerable.Range(0, 5).Select(i => new ConstUInt32()).ToArray();
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
             rw.RwUInt32(ref this.Enable);
             rw.RwUInt32(ref this.Unk);
 
-            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
-            rw.RwUInt32(ref this.UNUSED_UINT32[1]);
+            rw.RwObj(ref this.UNUSED_UINT32[0], args);
+            rw.RwObj(ref this.UNUSED_UINT32[1], args);
 
             rw.RwFloat32(ref this.Cyan);
             rw.RwFloat32(ref this.Magenta);
@@ -37,12 +37,9 @@ public partial class CommandTypes
             rw.RwFloat32(ref this.Dodge);
             rw.RwFloat32(ref this.Burn);
 
-            rw.RwUInt32(ref this.UNUSED_UINT32[2]);
-            rw.RwUInt32(ref this.UNUSED_UINT32[3]);
-            rw.RwUInt32(ref this.UNUSED_UINT32[4]);
-
-            for (int i=0; i<this.UNUSED_UINT32.Length; i++)
-                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
+            rw.RwObj(ref this.UNUSED_UINT32[2], args);
+            rw.RwObj(ref this.UNUSED_UINT32[3], args);
+            rw.RwObj(ref this.UNUSED_UINT32[4], args);
         }
     }
 }

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/EnDf.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/EnDf.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Linq;
 
 using Serialization;
 
@@ -25,7 +25,7 @@ public partial class CommandTypes
         public float BlurStrength = 1.0F;
         public UInt32 BlurType;
 
-        public UInt32[] UNUSED_UINT32 = new UInt32[3];
+        public ConstUInt32[] UNUSED_UINT32 = Enumerable.Range(0, 3).Select(i => new ConstUInt32()).ToArray();
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
@@ -33,8 +33,7 @@ public partial class CommandTypes
             rw.RwUInt32(ref this.Unk2);
             rw.RwUInt32(ref this.Unk3);
 
-            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
-            Trace.Assert(this.UNUSED_UINT32[0] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[0]}) in reserve variable.");
+            rw.RwObj(ref this.UNUSED_UINT32[0], args);
 
             rw.RwFloat32(ref this.FocalPlaneDistance);
             rw.RwFloat32(ref this.NearBlurSurface);
@@ -45,11 +44,8 @@ public partial class CommandTypes
             rw.RwFloat32(ref this.BlurStrength);
             rw.RwUInt32(ref this.BlurType);
 
-            for (int i=1; i<this.UNUSED_UINT32.Length; i++)
-            {
-                rw.RwUInt32(ref this.UNUSED_UINT32[i]);
-                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
-            }
+            rw.RwObj(ref this.UNUSED_UINT32[1], args);
+            rw.RwObj(ref this.UNUSED_UINT32[2], args);
         }
     }
 }

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/EnFD.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/EnFD.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Linq;
 
 using Serialization;
 
@@ -20,18 +20,15 @@ public partial class CommandTypes
         public float EndDistance   = 2000;
         public UInt32 RGBA         = 0x7F7F7F00;
 
-        public UInt32[] UNUSED_UINT32 = new UInt32[2];
+        public ConstUInt32[] UNUSED_UINT32 = Enumerable.Range(0, 2).Select(i => new ConstUInt32()).ToArray();
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
             rw.RwObj(ref this.Flags);
             rw.RwUInt32(ref this.Unk);
 
-            for (int i=0; i<this.UNUSED_UINT32.Length; i++)
-            {
-                rw.RwUInt32(ref this.UNUSED_UINT32[i]);
-                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
-            }
+            rw.RwObj(ref this.UNUSED_UINT32[0], args);
+            rw.RwObj(ref this.UNUSED_UINT32[1], args);
 
             rw.RwUInt32(ref this.Mode);
             rw.RwFloat32(ref this.StartDistance);

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/EnFH.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/EnFH.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Linq;
 
 using Serialization;
 
@@ -19,24 +19,21 @@ public partial class CommandTypes
         public float EndHeight   = 2000;
         public UInt32 RGBA       = 0x7F7F7F00;
 
-        public UInt32[] UNUSED_UINT32 = new UInt32[3];
+        public ConstUInt32[] UNUSED_UINT32 = Enumerable.Range(0, 3).Select(i => new ConstUInt32()).ToArray();
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
             rw.RwUInt32(ref this.Unk1);
             rw.RwUInt32(ref this.Unk2);
 
-            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
-            rw.RwUInt32(ref this.UNUSED_UINT32[1]);
+            rw.RwObj(ref this.UNUSED_UINT32[0], args);
+            rw.RwObj(ref this.UNUSED_UINT32[1], args);
 
             rw.RwFloat32(ref this.StartHeight);
             rw.RwFloat32(ref this.EndHeight);
             rw.RwUInt32(ref this.RGBA);
 
-            rw.RwUInt32(ref this.UNUSED_UINT32[2]);
-
-            for (int i=0; i<this.UNUSED_UINT32.Length; i++)
-                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
+            rw.RwObj(ref this.UNUSED_UINT32[2], args);
 
         }
     }

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/EnHd.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/EnHd.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Linq;
 
 using Serialization;
 
@@ -35,18 +35,15 @@ public partial class CommandTypes
         public UInt32 RGBA2;
         public UInt32 RGBA3;
 
-        public UInt32[] UNUSED_UINT32 = new UInt32[2];
+        public ConstUInt32[] UNUSED_UINT32 = Enumerable.Range(0, 2).Select(i => new ConstUInt32()).ToArray();
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
             rw.RwObj(ref this.Flags);
             rw.RwUInt32(ref this.Unk1);
 
-            for (int i=0; i<this.UNUSED_UINT32.Length; i++)
-            {
-                rw.RwUInt32(ref this.UNUSED_UINT32[i]);
-                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
-            }
+            rw.RwObj(ref this.UNUSED_UINT32[0], args);
+            rw.RwObj(ref this.UNUSED_UINT32[1], args);
 
             rw.RwFloat32(ref this.ToneMapMediumBrightness);
             rw.RwFloat32(ref this.ToneMapBloomStrength);

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/EnL0.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/EnL0.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Linq;
 
 using Serialization;
 
@@ -12,27 +12,24 @@ public partial class CommandTypes
     {
         public const int DataSize = 48;
 
-        public UInt32 Unk1 = 1;
-        public UInt32 Unk2 = 4354;
+        public ConstUInt32 Unk1 = new ConstUInt32(1);
+        public UInt32      Unk2 = 4354;
 
-        public UInt32 AmbientRGBA = 0xBFBFBFFF;
-        public UInt32 DiffuseRGBA = 0xE5E5E5FF;
+        public UInt32 AmbientRGBA  = 0xBFBFBFFF;
+        public UInt32 DiffuseRGBA  = 0xE5E5E5FF;
         public UInt32 SpecularRGBA = 0xFFFFFFFF;
 
         public float[] Direction = new float[] {0.0F, 0.5299989581108093F, 0.847998321056366F};
 
-        public UInt32[] UNUSED_UINT32 = new UInt32[4];
+        public ConstUInt32[] UNUSED_UINT32 = Enumerable.Range(0, 4).Select(i => new ConstUInt32()).ToArray();
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
-            rw.RwUInt32(ref this.Unk1);
-            Trace.Assert(this.Unk1 == 1, $"Unexpected value ({this.Unk2}) in constant field (expected value: 4354).");
-
+            rw.RwObj(ref this.Unk1, args);
             rw.RwUInt32(ref this.Unk2);
-            Trace.Assert(this.Unk2 == 4354, $"Unexpected value ({this.Unk2}) in constant field (expected value: 4354).");
 
-            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
-            rw.RwUInt32(ref this.UNUSED_UINT32[1]);
+            rw.RwObj(ref this.UNUSED_UINT32[0], args);
+            rw.RwObj(ref this.UNUSED_UINT32[1], args);
 
             rw.RwUInt32(ref this.AmbientRGBA);
             rw.RwUInt32(ref this.DiffuseRGBA);
@@ -40,11 +37,8 @@ public partial class CommandTypes
 
             rw.RwFloat32s(ref this.Direction, 3);
 
-            rw.RwUInt32(ref this.UNUSED_UINT32[2]);
-            rw.RwUInt32(ref this.UNUSED_UINT32[3]);
-
-            for (int i=0; i<this.UNUSED_UINT32.Length; i++)
-                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
+            rw.RwObj(ref this.UNUSED_UINT32[2], args);
+            rw.RwObj(ref this.UNUSED_UINT32[3], args);
         }
     }
 }

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/EnLI.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/EnLI.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Linq;
 
 using Serialization;
 
@@ -12,27 +12,24 @@ public partial class CommandTypes
     {
         public const int DataSize = 48;
 
-        public UInt32 Unk1 = 1;
-        public UInt32 Unk2 = 4354;
+        public ConstUInt32 Unk1 = new ConstUInt32(1);
+        public UInt32      Unk2 = 4354;
 
-        public UInt32 AmbientRGBA = 0xBFBFBFFF;
-        public UInt32 DiffuseRGBA = 0xE5E5E5FF;
+        public UInt32 AmbientRGBA  = 0xBFBFBFFF;
+        public UInt32 DiffuseRGBA  = 0xE5E5E5FF;
         public UInt32 SpecularRGBA = 0xFFFFFFFF;
 
         public float[] Direction = new float[] {0.0F, 0.5299989581108093F, 0.847998321056366F};
 
-        public UInt32[] UNUSED_UINT32 = new UInt32[4];
+        public ConstUInt32[] UNUSED_UINT32 = Enumerable.Range(0, 4).Select(i => new ConstUInt32()).ToArray();
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
-            rw.RwUInt32(ref this.Unk1);
-            Trace.Assert(this.Unk1 == 1, $"Unexpected value ({this.Unk2}) in constant field (expected value: 4354).");
-
+            rw.RwObj(ref this.Unk1, args);
             rw.RwUInt32(ref this.Unk2);
-            Trace.Assert(this.Unk2 == 4354, $"Unexpected value ({this.Unk2}) in constant field (expected value: 4354).");
 
-            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
-            rw.RwUInt32(ref this.UNUSED_UINT32[1]);
+            rw.RwObj(ref this.UNUSED_UINT32[0], args);
+            rw.RwObj(ref this.UNUSED_UINT32[1], args);
 
             rw.RwUInt32(ref this.AmbientRGBA);
             rw.RwUInt32(ref this.DiffuseRGBA);
@@ -40,11 +37,8 @@ public partial class CommandTypes
 
             rw.RwFloat32s(ref this.Direction, 3);
 
-            rw.RwUInt32(ref this.UNUSED_UINT32[2]);
-            rw.RwUInt32(ref this.UNUSED_UINT32[3]);
-
-            for (int i=0; i<this.UNUSED_UINT32.Length; i++)
-                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
+            rw.RwObj(ref this.UNUSED_UINT32[2], args);
+            rw.RwObj(ref this.UNUSED_UINT32[3], args);
         }
     }
 }

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/EnOl.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/EnOl.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 
 using Serialization;
 
@@ -12,8 +11,8 @@ public partial class CommandTypes
     {
         public const int DataSize = 32;
 
-        public UInt32 Unk1 = 1;
-        public UInt32 Unk2 = 4354;
+        public ConstUInt32 Unk1 = new ConstUInt32(1);
+        public UInt32      Unk2 = 4354;
 
         public float Strength;
         public float Width = 1.01F;
@@ -21,15 +20,12 @@ public partial class CommandTypes
         public float RangeMin = 100.0F;
         public float RangeMax = 150.0F;
 
-        public UInt32[] UNUSED_UINT32 = new UInt32[1];
+        public ConstUInt32 UNUSED_UINT32 = new ConstUInt32();
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
-            rw.RwUInt32(ref this.Unk1);
-            Trace.Assert(this.Unk1 == 1, $"Unexpected value ({this.Unk2}) in constant field (expected value: 4354).");
-
+            rw.RwObj(ref this.Unk1, args);
             rw.RwUInt32(ref this.Unk2);
-            Trace.Assert(this.Unk2 == 4354, $"Unexpected value ({this.Unk2}) in constant field (expected value: 4354).");
 
             rw.RwFloat32(ref this.Strength);
             rw.RwFloat32(ref this.Width);
@@ -37,8 +33,7 @@ public partial class CommandTypes
             rw.RwFloat32(ref this.RangeMin);
             rw.RwFloat32(ref this.RangeMax);
 
-            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
-            Trace.Assert(this.UNUSED_UINT32[0] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[0]}) in reserve variable.");
+            rw.RwObj(ref this.UNUSED_UINT32, args);
         }
     }
 }

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/EnPh.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/EnPh.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Linq;
 
 using Serialization;
 
@@ -14,17 +14,15 @@ public partial class CommandTypes
 
         public UInt32 Enable = 1;
 
-        public UInt32[] UNUSED_UINT32 = new UInt32[3];
+        public ConstUInt32[] UNUSED_UINT32 = Enumerable.Range(0, 3).Select(i => new ConstUInt32()).ToArray();
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
             rw.RwUInt32(ref this.Enable);
 
-            for (int i=0; i<this.UNUSED_UINT32.Length; i++)
-            {
-                rw.RwUInt32(ref this.UNUSED_UINT32[i]);
-                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
-            }
+            rw.RwObj(ref this.UNUSED_UINT32[0], args);
+            rw.RwObj(ref this.UNUSED_UINT32[1], args);
+            rw.RwObj(ref this.UNUSED_UINT32[2], args);
         }
     }
 }

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/EnSh.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/EnSh.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Linq;
 
 using Serialization;
 
@@ -22,17 +22,16 @@ public partial class CommandTypes
         public float Diffuse = 1.0F;
         public float CascadedShadowMapPartitionInterval = 0.12F;
 
-        public UInt32[] UNUSED_UINT32 = new UInt32[5];
+        public ConstUInt32[] UNUSED_UINT32 = Enumerable.Range(0, 5).Select(i => new ConstUInt32()).ToArray();
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
-            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
+            rw.RwObj(ref this.UNUSED_UINT32[0], args);
 
             rw.RwUInt32(ref this.Unk);
-            Trace.Assert(this.Unk == 4354, $"Unexpected value ({this.Unk}) in constant field (expected value: 4354).");
 
-            rw.RwUInt32(ref this.UNUSED_UINT32[1]);
-            rw.RwUInt32(ref this.UNUSED_UINT32[2]);
+            rw.RwObj(ref this.UNUSED_UINT32[1], args);
+            rw.RwObj(ref this.UNUSED_UINT32[2], args);
 
             rw.RwObj(ref this.Flags);
 
@@ -42,11 +41,8 @@ public partial class CommandTypes
             rw.RwFloat32(ref this.Diffuse);
             rw.RwFloat32(ref this.CascadedShadowMapPartitionInterval);
 
-            rw.RwUInt32(ref this.UNUSED_UINT32[3]);
-            rw.RwUInt32(ref this.UNUSED_UINT32[4]);
-
-            for (int i=0; i<this.UNUSED_UINT32.Length; i++)
-                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
+            rw.RwObj(ref this.UNUSED_UINT32[3], args);
+            rw.RwObj(ref this.UNUSED_UINT32[4], args);
         }
     }
 }

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/EnSs.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/EnSs.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Linq;
 
 using Serialization;
 
@@ -21,16 +21,15 @@ public partial class CommandTypes
         public float Concentration = 1.0F;
         public float Blur = 1.5F;
 
-        public UInt32[] UNUSED_UINT32 = new UInt32[5];
+        public ConstUInt32[] UNUSED_UINT32 = Enumerable.Range(0, 5).Select(i => new ConstUInt32()).ToArray();
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
             rw.RwUInt32(ref this.Enable);
             rw.RwUInt32(ref this.Unk);
-            Trace.Assert(this.Unk == 4354, $"Unexpected value ({this.Unk}) in constant field (expected value: 4354).");
 
-            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
-            rw.RwUInt32(ref this.UNUSED_UINT32[1]);
+            rw.RwObj(ref this.UNUSED_UINT32[0], args);
+            rw.RwObj(ref this.UNUSED_UINT32[1], args);
 
             rw.RwFloat32(ref this.Range);
             rw.RwFloat32(ref this.Radius);
@@ -38,12 +37,9 @@ public partial class CommandTypes
             rw.RwFloat32(ref this.Concentration);
             rw.RwFloat32(ref this.Blur);
 
-            rw.RwUInt32(ref this.UNUSED_UINT32[2]);
-            rw.RwUInt32(ref this.UNUSED_UINT32[3]);
-            rw.RwUInt32(ref this.UNUSED_UINT32[4]);
-
-            for (int i=0; i<this.UNUSED_UINT32.Length; i++)
-                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
+            rw.RwObj(ref this.UNUSED_UINT32[2], args);
+            rw.RwObj(ref this.UNUSED_UINT32[3], args);
+            rw.RwObj(ref this.UNUSED_UINT32[4], args);
         }
     }
 }

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/Env_.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/Env_.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Linq;
 
 using Serialization;
 
@@ -14,19 +14,16 @@ public partial class CommandTypes
 
         public Int32 ObjectId;
 
-        public UInt32[] UNUSED_UINT32 = new UInt32[3];
+        public ConstUInt32[] UNUSED_UINT32 = Enumerable.Range(0, 3).Select(i => new ConstUInt32()).ToArray();
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
-            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
+            rw.RwObj(ref this.UNUSED_UINT32[0], args);
 
             rw.RwInt32(ref this.ObjectId);
 
-            rw.RwUInt32(ref this.UNUSED_UINT32[1]);
-            rw.RwUInt32(ref this.UNUSED_UINT32[2]);
-
-            for (int i=0; i<this.UNUSED_UINT32.Length; i++)
-                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
+            rw.RwObj(ref this.UNUSED_UINT32[1], args);
+            rw.RwObj(ref this.UNUSED_UINT32[2], args);
         }
     }
 }

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/FAA_.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/FAA_.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Linq;
 
 using Serialization;
 
@@ -20,7 +20,7 @@ public partial class CommandTypes
         public AnimationStruct FirstAnimation = new AnimationStruct(loopBool:0, endingFrame:0, weight:1.0F);
         public AnimationStruct SecondAnimation = new AnimationStruct(loopBool:0, endingFrame:0, weight:1.0F);
 
-        public UInt32[] UNUSED_UINT32 = new UInt32[3];
+        public ConstUInt32[] UNUSED_UINT32 = Enumerable.Range(0, 3).Select(i => new ConstUInt32()).ToArray();
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
@@ -29,7 +29,7 @@ public partial class CommandTypes
 
             rw.RwObj(ref this.Flags);
 
-            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
+            rw.RwObj(ref this.UNUSED_UINT32[0], args);
 
             rw.RwUInt32(ref this.FirstAnimation.Index);
             rw.RwUInt32(ref this.FirstAnimation.StartingFrame);
@@ -39,7 +39,7 @@ public partial class CommandTypes
             rw.RwFloat32(ref this.FirstAnimation.Weight);
             rw.RwFloat32(ref this.FirstAnimation.PlaybackSpeed);
 
-            rw.RwUInt32(ref this.UNUSED_UINT32[1]);
+            rw.RwObj(ref this.UNUSED_UINT32[1], args);
 
             rw.RwUInt32(ref this.SecondAnimation.Index);
             rw.RwUInt32(ref this.SecondAnimation.StartingFrame);
@@ -49,10 +49,7 @@ public partial class CommandTypes
             rw.RwFloat32(ref this.SecondAnimation.Weight);
             rw.RwFloat32(ref this.SecondAnimation.PlaybackSpeed);
 
-            rw.RwUInt32(ref this.UNUSED_UINT32[2]);
-
-            for (int i=1; i<this.UNUSED_UINT32.Length; i++)
-                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
+            rw.RwObj(ref this.UNUSED_UINT32[2], args);
         }
     }
 }

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/FAB_.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/FAB_.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Linq;
 
 using Serialization;
 
@@ -18,15 +18,15 @@ public partial class CommandTypes
         public AnimationStruct FirstAnimation = new AnimationStruct(loopBool:0, endingFrame:0);
         public AnimationStruct SecondAnimation = new AnimationStruct(loopBool:0, endingFrame:0);
 
-        public UInt32[] UNUSED_UINT32 = new UInt32[6];
+        public ConstUInt32[] UNUSED_UINT32 = Enumerable.Range(0, 6).Select(i => new ConstUInt32()).ToArray();
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
             rw.RwObj(ref this.Flags);
             rw.RwUInt32(ref this.ObjectIndex);
 
-            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
-            rw.RwUInt32(ref this.UNUSED_UINT32[1]);
+            rw.RwObj(ref this.UNUSED_UINT32[0], args);
+            rw.RwObj(ref this.UNUSED_UINT32[1], args);
 
             rw.RwUInt32(ref this.FirstAnimation.Index);
             rw.RwUInt32(ref this.FirstAnimation.StartingFrame);
@@ -35,8 +35,8 @@ public partial class CommandTypes
             rw.RwUInt32(ref this.FirstAnimation.LoopBool);
             rw.RwFloat32(ref this.FirstAnimation.PlaybackSpeed);
 
-            rw.RwUInt32(ref this.UNUSED_UINT32[2]);
-            rw.RwUInt32(ref this.UNUSED_UINT32[3]);
+            rw.RwObj(ref this.UNUSED_UINT32[2], args);
+            rw.RwObj(ref this.UNUSED_UINT32[3], args);
 
             rw.RwUInt32(ref this.SecondAnimation.Index);
             rw.RwUInt32(ref this.SecondAnimation.StartingFrame);
@@ -45,11 +45,8 @@ public partial class CommandTypes
             rw.RwUInt32(ref this.SecondAnimation.LoopBool);
             rw.RwFloat32(ref this.SecondAnimation.PlaybackSpeed);
 
-            rw.RwUInt32(ref this.UNUSED_UINT32[4]);
-            rw.RwUInt32(ref this.UNUSED_UINT32[5]);
-
-            for (int i=1; i<this.UNUSED_UINT32.Length; i++)
-                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
+            rw.RwObj(ref this.UNUSED_UINT32[4], args);
+            rw.RwObj(ref this.UNUSED_UINT32[5], args);
         }
     }
 }

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/FDFl.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/FDFl.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Linq;
 
 using Serialization;
 
@@ -15,18 +15,16 @@ public partial class CommandTypes
         public UInt32 Unk1;
         public UInt32 Unk2 = 4354;
 
-        public UInt32[] UNUSED_UINT32 = new UInt32[2];
+        public ConstUInt32[] UNUSED_UINT32 = Enumerable.Range(0, 2).Select(i => new ConstUInt32()).ToArray();
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
-            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
-            Trace.Assert(this.UNUSED_UINT32[0] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[0]}) in reserve variable.");
+            rw.RwObj(ref this.UNUSED_UINT32[0], args);
 
             rw.RwUInt32(ref this.Unk1);
             rw.RwUInt32(ref this.Unk2);
 
-            rw.RwUInt32(ref this.UNUSED_UINT32[1]);
-            Trace.Assert(this.UNUSED_UINT32[1] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[1]}) in reserve variable.");
+            rw.RwObj(ref this.UNUSED_UINT32[1], args);
         }
     }
 }

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/FGFl.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/FGFl.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Linq;
 
 using Serialization;
 
@@ -14,19 +14,16 @@ public partial class CommandTypes
 
         public UInt32 Unk;
 
-        public UInt32[] UNUSED_UINT32 = new UInt32[3];
+        public ConstUInt32[] UNUSED_UINT32 = Enumerable.Range(0, 3).Select(i => new ConstUInt32()).ToArray();
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
-            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
+            rw.RwObj(ref this.UNUSED_UINT32[0], args);
 
             rw.RwUInt32(ref this.Unk);
 
-            rw.RwUInt32(ref this.UNUSED_UINT32[1]);
-            rw.RwUInt32(ref this.UNUSED_UINT32[2]);
-            
-            for (int i=0; i<this.UNUSED_UINT32.Length; i++)
-                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
+            rw.RwObj(ref this.UNUSED_UINT32[1], args);
+            rw.RwObj(ref this.UNUSED_UINT32[2], args);
         }
     }
 }

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/FOD_.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/FOD_.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Linq;
 
 using Serialization;
 
@@ -15,18 +15,15 @@ public partial class CommandTypes
         public UInt32 EnableFieldObject;
         public Int32 ObjectIndex;
 
-        public UInt32[] UNUSED_UINT32 = new UInt32[2];
+        public ConstUInt32[] UNUSED_UINT32 = Enumerable.Range(0, 2).Select(i => new ConstUInt32()).ToArray();
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
             rw.RwUInt32(ref this.EnableFieldObject);
             rw.RwInt32(ref this.ObjectIndex);
 
-            for (int i=0; i<this.UNUSED_UINT32.Length; i++)
-            {
-                rw.RwUInt32(ref this.UNUSED_UINT32[i]);
-                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
-            }
+            rw.RwObj(ref this.UNUSED_UINT32[0], args);
+            rw.RwObj(ref this.UNUSED_UINT32[1], args);
         }
     }
 }

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/FS__.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/FS__.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Linq;
 
 using Serialization;
 
@@ -19,26 +19,23 @@ public partial class CommandTypes
 
         public float UnkFloat;
 
-        public UInt32[] UNUSED_UINT32 = new UInt32[4];
+        public ConstUInt32[] UNUSED_UINT32 = Enumerable.Range(0, 4).Select(i => new ConstUInt32()).ToArray();
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
-            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
+            rw.RwObj(ref this.UNUSED_UINT32[0], args);
 
             rw.RwUInt32(ref this.UnkBool);
 
-            rw.RwUInt32(ref this.UNUSED_UINT32[1]);
-            rw.RwUInt32(ref this.UNUSED_UINT32[2]);
+            rw.RwObj(ref this.UNUSED_UINT32[1], args);
+            rw.RwObj(ref this.UNUSED_UINT32[2], args);
 
             rw.RwFloat32s(ref this.Coordinates, 3);
             rw.RwFloat32s(ref this.Rotation, 3);
 
             rw.RwFloat32(ref this.UnkFloat);
 
-            rw.RwUInt32(ref this.UNUSED_UINT32[3]);
-
-            for (int i=0; i<this.UNUSED_UINT32.Length; i++)
-                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
+            rw.RwObj(ref this.UNUSED_UINT32[3], args);
         }
     }
 }

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/FrJ_.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/FrJ_.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Linq;
 
 using Serialization;
 
@@ -14,16 +14,15 @@ public partial class CommandTypes
 
         public UInt32 JumpToFrame;
 
-        public UInt32[] UNUSED_UINT32 = new UInt32[3];
+        public ConstUInt32[] UNUSED_UINT32 = Enumerable.Range(0, 3).Select(i => new ConstUInt32()).ToArray();
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
-            rw.RwUInt32(ref this.JumpToFrame);      // (should be shown as 0 through the EVT's total number of frames -- can jump forward or backward)
-            for (int i=0; i<3; i++)
-            {
-                rw.RwUInt32(ref this.UNUSED_UINT32[i]);
-                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
-            }
+            rw.RwUInt32(ref this.JumpToFrame);
+
+            rw.RwObj(ref this.UNUSED_UINT32[0], args);
+            rw.RwObj(ref this.UNUSED_UINT32[1], args);
+            rw.RwObj(ref this.UNUSED_UINT32[2], args);
         }
     }
 }

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/MAAB.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/MAAB.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Linq;
 
 using Serialization;
 
@@ -19,15 +19,15 @@ public partial class CommandTypes
         public AnimationStruct FirstAnimation = new AnimationStruct(loopBool:0, endingFrame:0);
         public AnimationStruct SecondAnimation = new AnimationStruct(loopBool:1, endingFrame:0);
 
-        public UInt32[] UNUSED_UINT32 = new UInt32[6];
+        public ConstUInt32[] UNUSED_UINT32 = Enumerable.Range(0, 6).Select(i => new ConstUInt32()).ToArray();
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
             rw.RwObj(ref this.Flags);
             rw.RwInt32(ref this.ChildObjectId);
 
-            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
-            rw.RwUInt32(ref this.UNUSED_UINT32[1]);
+            rw.RwObj(ref this.UNUSED_UINT32[0], args);
+            rw.RwObj(ref this.UNUSED_UINT32[1], args);
 
             rw.RwUInt32(ref this.FirstAnimation.Index);
             rw.RwUInt32(ref this.FirstAnimation.InterpolatedFrames);
@@ -36,8 +36,8 @@ public partial class CommandTypes
             rw.RwUInt32(ref this.FirstAnimation.StartingFrame);
             rw.RwUInt32(ref this.FirstAnimation.EndingFrame);
 
-            rw.RwUInt32(ref this.UNUSED_UINT32[2]);
-            rw.RwUInt32(ref this.UNUSED_UINT32[3]);
+            rw.RwObj(ref this.UNUSED_UINT32[2], args);
+            rw.RwObj(ref this.UNUSED_UINT32[3], args);
 
             rw.RwUInt32(ref this.SecondAnimation.Index);
             rw.RwUInt32(ref this.SecondAnimation.InterpolatedFrames);
@@ -46,11 +46,8 @@ public partial class CommandTypes
             rw.RwUInt32(ref this.SecondAnimation.StartingFrame);
             rw.RwUInt32(ref this.SecondAnimation.EndingFrame);
 
-            rw.RwUInt32(ref this.UNUSED_UINT32[4]);
-            rw.RwUInt32(ref this.UNUSED_UINT32[5]);
-
-            for (int i=0; i<this.UNUSED_UINT32.Length; i++)
-                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
+            rw.RwObj(ref this.UNUSED_UINT32[4], args);
+            rw.RwObj(ref this.UNUSED_UINT32[5], args);
         }
     }
 }

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/MAB_.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/MAB_.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Linq;
 
 using Serialization;
 
@@ -24,7 +24,7 @@ public partial class CommandTypes
 
         public UInt32 StartWaitingFrames;
 
-        public UInt32[] UNUSED_UINT32 = new UInt32[2];
+        public ConstUInt32[] UNUSED_UINT32 = Enumerable.Range(0, 2).Select(i => new ConstUInt32()).ToArray();
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
@@ -62,11 +62,8 @@ public partial class CommandTypes
 
             rw.RwUInt32(ref this.StartWaitingFrames);
 
-            for (int i=0; i<2; i++)
-            {
-                rw.RwUInt32(ref this.UNUSED_UINT32[i]);
-                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
-            }
+            rw.RwObj(ref this.UNUSED_UINT32[0], args);
+            rw.RwObj(ref this.UNUSED_UINT32[1], args);
         }
     }
 }

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/MAI_.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/MAI_.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 
 using Serialization;
@@ -17,11 +16,11 @@ public partial class CommandTypes
 
         public AnimationStruct[] IdleAnimations = Enumerable.Range(0, 10).Select(_ => new AnimationStruct(endingFrame:0)).ToArray();
 
-        public UInt32[] UNUSED_UINT32 = new UInt32[4];
+        public ConstUInt32[] UNUSED_UINT32 = Enumerable.Range(0, 4).Select(i => new ConstUInt32()).ToArray();
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
-            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
+            rw.RwObj(ref this.UNUSED_UINT32[0], args);
 
             for (int i=0; i<10; i++)
             {
@@ -33,12 +32,9 @@ public partial class CommandTypes
                 rw.RwFloat32(ref this.IdleAnimations[i].PlaybackSpeed);
             }
 
-            rw.RwUInt32(ref this.UNUSED_UINT32[1]);
-            rw.RwUInt32(ref this.UNUSED_UINT32[2]);
-            rw.RwUInt32(ref this.UNUSED_UINT32[3]);
-
-            for (int i=0; i<this.UNUSED_UINT32.Length; i++)
-                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
+            rw.RwObj(ref this.UNUSED_UINT32[1], args);
+            rw.RwObj(ref this.UNUSED_UINT32[2], args);
+            rw.RwObj(ref this.UNUSED_UINT32[3], args);
         }
     }
 }

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/MAlp.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/MAlp.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 
 using Serialization;
 
@@ -16,24 +15,20 @@ public partial class CommandTypes
         public UInt32 InterpolationParameters = 4354;
         public byte TranslucentMode;
 
-        public byte UNUSED_UINT8;
-        public UInt16 UNUSED_UINT16;
-        public UInt32 UNUSED_UINT32;
+        public ConstUInt8  UNUSED_UINT8  = new ConstUInt8();
+        public ConstUInt16 UNUSED_UINT16 = new ConstUInt16();
+        public ConstUInt32 UNUSED_UINT32 = new ConstUInt32();
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
-            rw.RwUInt32(ref this.UNUSED_UINT32);
-            Trace.Assert(this.UNUSED_UINT32 == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32}) in reserve variable.");
+            rw.RwObj(ref this.UNUSED_UINT32, args);
 
             rw.RwUInt8s(ref this.RGBA, 4);
             rw.RwUInt32(ref this.InterpolationParameters);
             rw.RwUInt8(ref this.TranslucentMode);
 
-            rw.RwUInt8(ref this.UNUSED_UINT8);
-            Trace.Assert(this.UNUSED_UINT8 == 0, $"Unexpected nonzero value ({this.UNUSED_UINT8}) in reserve variable.");
-            rw.RwUInt16(ref this.UNUSED_UINT16);
-            Trace.Assert(this.UNUSED_UINT16 == 0, $"Unexpected nonzero value ({this.UNUSED_UINT16}) in reserve variable.");
-
+            rw.RwObj(ref this.UNUSED_UINT8, args);
+            rw.RwObj(ref this.UNUSED_UINT16, args);
         }
     }
 }

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/MAtO.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/MAtO.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Linq;
 
 using Serialization;
 
@@ -19,11 +19,11 @@ public partial class CommandTypes
 
         public UInt32 InterpolationType;
 
-        public UInt32[] UNUSED_UINT32 = new UInt32[4];
+        public ConstUInt32[] UNUSED_UINT32 = Enumerable.Range(0, 4).Select(i => new ConstUInt32()).ToArray();
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
-            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
+            rw.RwObj(ref this.UNUSED_UINT32[0], args);
 
             rw.RwInt32(ref this.ChildObjectId);
 
@@ -32,12 +32,9 @@ public partial class CommandTypes
 
             rw.RwUInt32(ref this.InterpolationType);
 
-            rw.RwUInt32(ref this.UNUSED_UINT32[1]);
-            rw.RwUInt32(ref this.UNUSED_UINT32[2]);
-            rw.RwUInt32(ref this.UNUSED_UINT32[3]);
-
-            for (int i=0; i<this.UNUSED_UINT32.Length; i++)
-                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
+            rw.RwObj(ref this.UNUSED_UINT32[1], args);
+            rw.RwObj(ref this.UNUSED_UINT32[2], args);
+            rw.RwObj(ref this.UNUSED_UINT32[3], args);
         }
     }
 }

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/MAt_.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/MAt_.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Linq;
 
 using Serialization;
 
@@ -20,7 +20,7 @@ public partial class CommandTypes
         public float[] RelativePosition = new float[3];
         public float[] Rotation = new float[3];
 
-        public UInt32[] UNUSED_UINT32 = new UInt32[3];
+        public ConstUInt32[] UNUSED_UINT32 = Enumerable.Range(0, 3).Select(i => new ConstUInt32()).ToArray();
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
@@ -29,16 +29,13 @@ public partial class CommandTypes
             rw.RwUInt32(ref this.HelperId);
             rw.RwInt32(ref this.ChildObjectId);
 
-            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
+            rw.RwObj(ref this.UNUSED_UINT32[0], args);
 
             rw.RwFloat32s(ref this.RelativePosition, 3);
             rw.RwFloat32s(ref this.Rotation, 3);
 
-            rw.RwUInt32(ref this.UNUSED_UINT32[1]);
-            rw.RwUInt32(ref this.UNUSED_UINT32[2]);
-
-            for (int i=0; i<this.UNUSED_UINT32.Length; i++)
-                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in MAt_ reserve variable.");
+            rw.RwObj(ref this.UNUSED_UINT32[1], args);
+            rw.RwObj(ref this.UNUSED_UINT32[2], args);
         }
     }
 }

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/MCSd.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/MCSd.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Linq;
 
 using Serialization;
 
@@ -20,7 +20,7 @@ public partial class CommandTypes
         public UInt16 InnerCircleDiameter = 20;
         public UInt16 OuterCircleDiameter = 40;
 
-        public UInt32[] UNUSED_UINT32 = new UInt32[4];
+        public ConstUInt32[] UNUSED_UINT32 = Enumerable.Range(0, 4).Select(i => new ConstUInt32()).ToArray();
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
@@ -29,17 +29,14 @@ public partial class CommandTypes
             rw.RwUInt32(ref this.InnerCircleRGBA);
             rw.RwUInt32(ref this.OuterCircleRGBA);
 
-            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
+            rw.RwObj(ref this.UNUSED_UINT32[0], args);
 
             rw.RwUInt16(ref this.InnerCircleDiameter);
             rw.RwUInt16(ref this.OuterCircleDiameter);
 
-            rw.RwUInt32(ref this.UNUSED_UINT32[1]);
-            rw.RwUInt32(ref this.UNUSED_UINT32[2]);
-            rw.RwUInt32(ref this.UNUSED_UINT32[3]);
-
-            for (int i=0; i<this.UNUSED_UINT32.Length; i++)
-                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
+            rw.RwObj(ref this.UNUSED_UINT32[1], args);
+            rw.RwObj(ref this.UNUSED_UINT32[2], args);
+            rw.RwObj(ref this.UNUSED_UINT32[3], args);
         }
     }
 }

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/MDt_.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/MDt_.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Linq;
 
 using Serialization;
 
@@ -20,7 +20,7 @@ public partial class CommandTypes
         public float[] Position = new float[3];
         public float[] Rotation = new float[3];
 
-        public UInt32[] UNUSED_UINT32 = new UInt32[3];
+        public ConstUInt32[] UNUSED_UINT32 = Enumerable.Range(0, 3).Select(i => new ConstUInt32()).ToArray();
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
@@ -29,16 +29,13 @@ public partial class CommandTypes
             rw.RwUInt32(ref this.HelperId);
             rw.RwInt32(ref this.ChildObjectId);
 
-            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
+            rw.RwObj(ref this.UNUSED_UINT32[0], args);
 
             rw.RwFloat32s(ref this.Position, 3);
             rw.RwFloat32s(ref this.Rotation, 3);
 
-            rw.RwUInt32(ref this.UNUSED_UINT32[1]);
-            rw.RwUInt32(ref this.UNUSED_UINT32[2]);
-
-            for (int i=0; i<this.UNUSED_UINT32.Length; i++)
-                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in MDt_ reserve variable.");
+            rw.RwObj(ref this.UNUSED_UINT32[1], args);
+            rw.RwObj(ref this.UNUSED_UINT32[2], args);
         }
     }
 }

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/MFts.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/MFts.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Linq;
 
 using Serialization;
 
@@ -16,7 +16,7 @@ public partial class CommandTypes
 
         public float Strength;
 
-        public UInt32[] UNUSED_UINT32 = new UInt32[2];
+        public ConstUInt32[] UNUSED_UINT32 = Enumerable.Range(0, 2).Select(i => new ConstUInt32()).ToArray();
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
@@ -24,11 +24,8 @@ public partial class CommandTypes
 
             rw.RwFloat32(ref this.Strength);
 
-            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
-            rw.RwUInt32(ref this.UNUSED_UINT32[1]);
-
-            for (int i=0; i<this.UNUSED_UINT32.Length; i++)
-                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
+            rw.RwObj(ref this.UNUSED_UINT32[0], args);
+            rw.RwObj(ref this.UNUSED_UINT32[1], args);
         }
     }
 }

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/MIc_.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/MIc_.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Linq;
 
 using Serialization;
 
@@ -15,16 +15,16 @@ public partial class CommandTypes
         public UInt32 IconType;
         public UInt32 IconSize;
 
-        public UInt32[] UNUSED_UINT32 = new UInt32[2];
+        public ConstUInt32[] UNUSED_UINT32 = Enumerable.Range(0, 2).Select(i => new ConstUInt32()).ToArray();
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
-            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
+            rw.RwObj(ref this.UNUSED_UINT32[0], args);
+
             rw.RwUInt32(ref this.IconType);
             rw.RwUInt32(ref this.IconSize);
-            rw.RwUInt32(ref this.UNUSED_UINT32[1]);
-            for (int i=0; i<this.UNUSED_UINT32.Length; i++)
-                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
+
+            rw.RwObj(ref this.UNUSED_UINT32[1], args);
         }
     }
 }

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/ML__.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/ML__.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Linq;
 
 using Serialization;
 
@@ -21,17 +21,15 @@ public partial class CommandTypes
 
         public float[] Direction = new float[] {0.0F, 0.5299989581108093F, 0.847998321056366F};
 
-        public UInt32[] UNUSED_UINT32 = new UInt32[4];
+        public ConstUInt32[] UNUSED_UINT32 = Enumerable.Range(0, 4).Select(i => new ConstUInt32()).ToArray();
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
             rw.RwUInt32(ref this.Enable);
-
             rw.RwUInt32(ref this.UNK);
-            Trace.Assert(this.UNK == 4354, $"Unexpected value ({this.UNK}) in constant field (expected value: 4354).");
 
-            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
-            rw.RwUInt32(ref this.UNUSED_UINT32[1]);
+            rw.RwObj(ref this.UNUSED_UINT32[0], args);
+            rw.RwObj(ref this.UNUSED_UINT32[1], args);
 
             rw.RwUInt32(ref this.AmbientRGBA);
             rw.RwUInt32(ref this.DiffuseRGBA);
@@ -39,11 +37,8 @@ public partial class CommandTypes
 
             rw.RwFloat32s(ref this.Direction, 3);
 
-            rw.RwUInt32(ref this.UNUSED_UINT32[2]);
-            rw.RwUInt32(ref this.UNUSED_UINT32[3]);
-
-            for (int i=0; i<this.UNUSED_UINT32.Length; i++)
-                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
+            rw.RwObj(ref this.UNUSED_UINT32[2], args);
+            rw.RwObj(ref this.UNUSED_UINT32[3], args);
         }
     }
 }

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/MLa_.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/MLa_.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 
 using Serialization;
 
@@ -17,11 +16,13 @@ public partial class CommandTypes
 
         public UInt16 MotionType;
         public UInt16 SpeedType = 2;
-        public UInt16 UNUSED;
+
         public UInt16 TargetType;
         public float[] Target = new float[3];
         public UInt32 TargetModelID;
         public UInt32 TargetHelperID;
+
+        public ConstUInt16 UNUSED_UINT16 = new ConstUInt16();
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
@@ -31,8 +32,7 @@ public partial class CommandTypes
             rw.RwUInt16(ref this.MotionType);
             rw.RwUInt16(ref this.SpeedType);
 
-            rw.RwUInt16(ref this.UNUSED);
-            Trace.Assert(this.UNUSED == 0, $"Unexpected nonzero value ({this.UNUSED}) in reserve variable.");
+            rw.RwObj(ref this.UNUSED_UINT16, args);
             
             rw.RwUInt16(ref this.TargetType);
             rw.RwFloat32s(ref this.Target, 3);

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/MLd_.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/MLd_.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Linq;
 
 using Serialization;
 
@@ -12,13 +12,11 @@ public partial class CommandTypes
     {
         public const int DataSize = 16;
 
-        public UInt32[] UNUSED_UINT32 = new UInt32[8];
+        public ConstUInt32[] UNUSED_UINT32 = Enumerable.Range(0, 4).Select(i => new ConstUInt32()).ToArray();
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
-            rw.RwUInt32s(ref this.UNUSED_UINT32, 4);
-            for (int i=0; i<this.UNUSED_UINT32.Length; i++)
-                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
+            rw.RwObjs(ref this.UNUSED_UINT32, 4, args);
         }
     }
 }

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/MLw_.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/MLw_.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 
 using Serialization;
 
@@ -22,7 +21,7 @@ public partial class CommandTypes
         public UInt32 UpdateIntervalMinimumFrameValue = 150;
         public UInt32 UpdateIntervalRandomFrame = 60;
 
-        public UInt32 UNUSED_UINT32;
+        public ConstUInt32 UNUSED_UINT32 = new ConstUInt32();
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
@@ -36,8 +35,7 @@ public partial class CommandTypes
             rw.RwUInt32(ref this.UpdateIntervalMinimumFrameValue);
             rw.RwUInt32(ref this.UpdateIntervalRandomFrame);
 
-            rw.RwUInt32(ref this.UNUSED_UINT32);
-            Trace.Assert(this.UNUSED_UINT32 == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32}) in reserve variable.");
+            rw.RwObj(ref this.UNUSED_UINT32, args);
         }
     }
 }

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/MMD_.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/MMD_.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 
 using Serialization;
 
@@ -27,12 +28,13 @@ public partial class CommandTypes
         public AnimationStruct MovingAnimation = new AnimationStruct(loopBool:1);
         public AnimationStruct WaitingAnimation = new AnimationStruct(loopBool:1);
 
-        public UInt16   UNUSED_UINT16;
-        public UInt32[] UNUSED_UINT32 = new UInt32[8];
+        public ConstUInt16   UNUSED_UINT16 = new ConstUInt16();
+        public ConstUInt32[] UNUSED_UINT32 = Enumerable.Range(0, 8).Select(i => new ConstUInt32()).ToArray();
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
-            Trace.Assert((int)args["dataSize"] == 96 || (int)args["dataSize"] == 384);
+            if ((int)args["dataSize"] != 96 && (int)args["dataSize"] != 384)
+                throw new Exception($"MMD_ command should have dataSize 96 or 384; instead has {(int)args["dataSize"]}");
 
             rw.RwUInt32(ref this.InterpolationType);
             rw.RwUInt32(ref this.NumControlGroups);
@@ -49,8 +51,7 @@ public partial class CommandTypes
             rw.RwUInt8(ref this.StartSpeedType);
             rw.RwUInt8(ref this.FinalSpeedType);
 
-            rw.RwUInt16(ref this.UNUSED_UINT16);
-            Trace.Assert(this.UNUSED_UINT16 == 0, $"Unexpected nonzero value ({this.UNUSED_UINT16}) in reserve variable.");
+            rw.RwObj(ref this.UNUSED_UINT16, args);
 
             rw.RwUInt32(ref this.MovingAnimation.Index);
             rw.RwUInt32(ref this.MovingAnimation.InterpolatedFrames);
@@ -58,9 +59,9 @@ public partial class CommandTypes
             rw.RwFloat32(ref this.MovingAnimation.PlaybackSpeed);
             rw.RwUInt32(ref this.MovingAnimation.StartingFrame);
 
-            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
-            rw.RwUInt32(ref this.UNUSED_UINT32[1]);
-            rw.RwUInt32(ref this.UNUSED_UINT32[2]);
+            rw.RwObj(ref this.UNUSED_UINT32[0], args);
+            rw.RwObj(ref this.UNUSED_UINT32[1], args);
+            rw.RwObj(ref this.UNUSED_UINT32[2], args);
 
             rw.RwUInt32(ref this.WaitingAnimation.Index);
             rw.RwUInt32(ref this.WaitingAnimation.InterpolatedFrames);
@@ -68,14 +69,11 @@ public partial class CommandTypes
             rw.RwFloat32(ref this.WaitingAnimation.PlaybackSpeed);
             rw.RwUInt32(ref this.WaitingAnimation.StartingFrame);
 
-            rw.RwUInt32(ref this.UNUSED_UINT32[3]);
-            rw.RwUInt32(ref this.UNUSED_UINT32[4]);
-            rw.RwUInt32(ref this.UNUSED_UINT32[5]);
-            rw.RwUInt32(ref this.UNUSED_UINT32[6]);
-            rw.RwUInt32(ref this.UNUSED_UINT32[7]);
-
-            for (int i=0; i<this.UNUSED_UINT32.Length; i++)
-                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
+            rw.RwObj(ref this.UNUSED_UINT32[3], args);
+            rw.RwObj(ref this.UNUSED_UINT32[4], args);
+            rw.RwObj(ref this.UNUSED_UINT32[5], args);
+            rw.RwObj(ref this.UNUSED_UINT32[6], args);
+            rw.RwObj(ref this.UNUSED_UINT32[7], args);
         }
     }
 }

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/MRgs.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/MRgs.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Linq;
 
 using Serialization;
 
@@ -15,17 +15,16 @@ public partial class CommandTypes
         public UInt32 DisplayType;
         public UInt32 Scene;
 
-        public UInt32[] UNUSED_UINT32 = new UInt32[2];
+        public ConstUInt32[] UNUSED_UINT32 = Enumerable.Range(0, 2).Select(i => new ConstUInt32()).ToArray();
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
-            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
+            rw.RwObj(ref this.UNUSED_UINT32[0], args);
+
             rw.RwUInt32(ref this.DisplayType);
             rw.RwUInt32(ref this.Scene);
-            rw.RwUInt32(ref this.UNUSED_UINT32[1]);
 
-            for (int i=0; i<this.UNUSED_UINT32.Length; i++)
-                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in MAt_ reserve variable.");
+            rw.RwObj(ref this.UNUSED_UINT32[1], args);
         }
     }
 }

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/MRot.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/MRot.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Linq;
 
 using Serialization;
 
@@ -20,7 +20,7 @@ public partial class CommandTypes
         public AnimationStruct RotatingAnimation = new AnimationStruct(loopBool:0);
         public AnimationStruct WaitingAnimation = new AnimationStruct(loopBool:1);
 
-        public UInt32[] UNUSED_UINT32 = new UInt32[8];
+        public ConstUInt32[] UNUSED_UINT32 = Enumerable.Range(0, 8).Select(i => new ConstUInt32()).ToArray();
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
@@ -29,8 +29,8 @@ public partial class CommandTypes
             rw.RwUInt32(ref this.InterpolationType);
             rw.RwUInt32(ref this.UNK);
 
-            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
-            rw.RwUInt32(ref this.UNUSED_UINT32[1]);
+            rw.RwObj(ref this.UNUSED_UINT32[0], args);
+            rw.RwObj(ref this.UNUSED_UINT32[1], args);
 
             rw.RwUInt32(ref this.RotatingAnimation.Index);
             rw.RwUInt32(ref this.RotatingAnimation.InterpolatedFrames);
@@ -38,9 +38,9 @@ public partial class CommandTypes
             rw.RwFloat32(ref this.RotatingAnimation.PlaybackSpeed);
             rw.RwUInt32(ref this.RotatingAnimation.StartingFrame);
 
-            rw.RwUInt32(ref this.UNUSED_UINT32[2]);
-            rw.RwUInt32(ref this.UNUSED_UINT32[3]);
-            rw.RwUInt32(ref this.UNUSED_UINT32[4]);
+            rw.RwObj(ref this.UNUSED_UINT32[2], args);
+            rw.RwObj(ref this.UNUSED_UINT32[3], args);
+            rw.RwObj(ref this.UNUSED_UINT32[4], args);
 
             rw.RwUInt32(ref this.WaitingAnimation.Index);
             rw.RwUInt32(ref this.WaitingAnimation.InterpolatedFrames);
@@ -48,12 +48,9 @@ public partial class CommandTypes
             rw.RwFloat32(ref this.WaitingAnimation.PlaybackSpeed);
             rw.RwUInt32(ref this.WaitingAnimation.StartingFrame);
 
-            rw.RwUInt32(ref this.UNUSED_UINT32[5]);
-            rw.RwUInt32(ref this.UNUSED_UINT32[6]);
-            rw.RwUInt32(ref this.UNUSED_UINT32[7]);
-
-            for (int i=0; i<this.UNUSED_UINT32.Length; i++)
-                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
+            rw.RwObj(ref this.UNUSED_UINT32[5], args);
+            rw.RwObj(ref this.UNUSED_UINT32[6], args);
+            rw.RwObj(ref this.UNUSED_UINT32[7], args);
         }
     }
 }

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/MSSs.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/MSSs.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Linq;
 
 using Serialization;
 
@@ -14,17 +14,16 @@ public partial class CommandTypes
 
         public UInt32 ShoeLayerIndex = 1;
 
-        public UInt32[] UNUSED_UINT32 = new UInt32[3];
+        public ConstUInt32[] UNUSED_UINT32 = Enumerable.Range(0, 3).Select(i => new ConstUInt32()).ToArray();
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
-            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
-            rw.RwUInt32(ref this.ShoeLayerIndex);  // observed values: 1, 2; also known to work with 3, 4 (should be shown based on the object model's shoe_ layer values)
-            rw.RwUInt32(ref this.UNUSED_UINT32[1]);
-            rw.RwUInt32(ref this.UNUSED_UINT32[2]);
+            rw.RwObj(ref this.UNUSED_UINT32[0], args);
 
-            for (int i=0; i<this.UNUSED_UINT32.Length; i++)
-                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
+            rw.RwUInt32(ref this.ShoeLayerIndex);  // observed values: 1, 2; also known to work with 3, 4 (should be shown based on the object model's shoe_ layer values)
+
+            rw.RwObj(ref this.UNUSED_UINT32[1], args);
+            rw.RwObj(ref this.UNUSED_UINT32[2], args);
         }
     }
 }

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/MScl.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/MScl.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Linq;
 
 using Serialization;
 
@@ -15,19 +15,16 @@ public partial class CommandTypes
         public UInt32 InterpolationParameters = 4354;
         public float Scale = 1;
 
-        public UInt32[] UNUSED_UINT32 = new UInt32[2];
+        public ConstUInt32[] UNUSED_UINT32 = Enumerable.Range(0, 2).Select(i => new ConstUInt32()).ToArray();
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
-            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
+            rw.RwObj(ref this.UNUSED_UINT32[0], args);
 
             rw.RwUInt32(ref this.InterpolationParameters);
             rw.RwFloat32(ref this.Scale);
 
-            rw.RwUInt32(ref this.UNUSED_UINT32[1]);
-
-            for (int i=0; i<this.UNUSED_UINT32.Length; i++)
-                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
+            rw.RwObj(ref this.UNUSED_UINT32[1], args);
         }
     }
 }

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/SBEA.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/SBEA.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Linq;
 
 using Serialization;
 
@@ -14,16 +14,16 @@ public partial class CommandTypes
 
         public Int32 Action;
 
-        public Int32[] UNUSED_INT32 = new Int32[3];
+        public ConstUInt32[] UNUSED_UINT32 = Enumerable.Range(0, 3).Select(i => new ConstUInt32()).ToArray();
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
-            rw.RwInt32(ref this.UNUSED_INT32[0]);
+            rw.RwObj(ref this.UNUSED_UINT32[0], args);
+
             rw.RwInt32(ref this.Action); // observed values: 1, 2
-            rw.RwInt32(ref this.UNUSED_INT32[1]);
-            rw.RwInt32(ref this.UNUSED_INT32[2]);
-            for (int i=0; i<this.UNUSED_INT32.Length; i++)
-                Trace.Assert(this.UNUSED_INT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_INT32[i]}) in reserve variable.");
+
+            rw.RwObj(ref this.UNUSED_UINT32[1], args);
+            rw.RwObj(ref this.UNUSED_UINT32[2], args);
         }
     }
 }

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/SBE_.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/SBE_.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 
 using Serialization;
 
@@ -16,15 +15,15 @@ public partial class CommandTypes
         public Int32 UnkEnum;
         public UInt32 CueId;
 
-        public UInt32 UNUSED_UINT32;
+        public ConstUInt32 UNUSED_UINT32 = new ConstUInt32();
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
             rw.RwInt32(ref this.Enable);         // observed values: 0, 1 (a boolean)
             rw.RwInt32(ref this.UnkEnum);        // observed values: 1, 2
             rw.RwUInt32(ref this.CueId);         // I'm currently hypothesizing that these are field noise sfx cues....
-            rw.RwUInt32(ref this.UNUSED_UINT32);
-            Trace.Assert(this.UNUSED_UINT32 == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32}) in reserve variable.");
+
+            rw.RwObj(ref this.UNUSED_UINT32, args);
         }
     }
 }

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/SFts.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/SFts.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Linq;
 
 using Serialization;
 
@@ -15,16 +15,15 @@ public partial class CommandTypes
         public Int32 Enable;
         public Int32 ObjectId;
 
-        public UInt32[] UNUSED_UINT32 = new UInt32[2];
+        public ConstUInt32[] UNUSED_UINT32 = Enumerable.Range(0, 2).Select(i => new ConstUInt32()).ToArray();
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
             rw.RwInt32(ref this.Enable);            // observed values: 0, 1 (a boolean)
             rw.RwInt32(ref this.ObjectId);
-            rw.RwUInt32(ref this.UNUSED_UINT32[0]);
-            rw.RwUInt32(ref this.UNUSED_UINT32[1]);
-            for (int i=0; i<this.UNUSED_UINT32.Length; i++)
-                Trace.Assert(this.UNUSED_UINT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_UINT32[i]}) in reserve variable.");
+
+            rw.RwObj(ref this.UNUSED_UINT32[0], args);
+            rw.RwObj(ref this.UNUSED_UINT32[1], args);
         }
     }
 }

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/Scr_.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/Scr_.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Linq;
 
 using Serialization;
 
@@ -14,16 +14,16 @@ public partial class CommandTypes
 
         public Int32 ProcedureIndex;
 
-        public Int32[] UNUSED_INT32 = new Int32[3];
+        public ConstUInt32[] UNUSED_UINT32 = Enumerable.Range(0, 3).Select(i => new ConstUInt32()).ToArray();
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
-            rw.RwInt32(ref this.UNUSED_INT32[0]);
+            rw.RwObj(ref this.UNUSED_UINT32[0], args);
+
             rw.RwInt32(ref this.ProcedureIndex); // (should be shown as 0 through the BF file's number of procedures)
-            rw.RwInt32(ref this.UNUSED_INT32[1]);
-            rw.RwInt32(ref this.UNUSED_INT32[2]);
-            for (int i=0; i<this.UNUSED_INT32.Length; i++)
-                Trace.Assert(this.UNUSED_INT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_INT32[i]}) in reserve variable.");
+
+            rw.RwObj(ref this.UNUSED_UINT32[1], args);
+            rw.RwObj(ref this.UNUSED_UINT32[2], args);
         }
     }
 }

--- a/src/lib/FileIO/Formats/EVT/CommandTypes/Snd_.cs
+++ b/src/lib/FileIO/Formats/EVT/CommandTypes/Snd_.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Linq;
 
 using Serialization;
 
@@ -18,20 +18,22 @@ public partial class CommandTypes
         public Int32 CueId;
         public Int32 FadeDuration;
 
-        public Int32[] UNUSED_INT32 = new Int32[3];
+        public ConstUInt32[] UNUSED_UINT32 = Enumerable.Range(0, 3).Select(i => new ConstUInt32()).ToArray();
 
         public void ExbipHook<T>(T rw, Dictionary<string, object> args) where T : struct, IBaseBinaryTarget
         {
-            rw.RwInt32(ref this.UNUSED_INT32[0]);
+            rw.RwObj(ref this.UNUSED_UINT32[0], args);
+
             rw.RwInt32(ref this.Source);           // observed values: 0, 1, 2, 3 (1 = bgm, 2 = system, 3 = event, 0 = ...skip)
             rw.RwInt32(ref this.Action);           // observed values: 0, 1, 2 (1 = play, 2 = stop, 0 = ...skip)
             rw.RwInt32(ref this.Channel);          // observed values: 0, 1, 2, 3 (some combo of mono/stereo/left/right...? or "respect ADX" vs. "no do this actually"?)
             rw.RwInt32(ref this.CueId);
-            rw.RwInt32(ref this.UNUSED_INT32[1]);
+
+            rw.RwObj(ref this.UNUSED_UINT32[1], args);
+
             rw.RwInt32(ref this.FadeDuration);     // in milliseconds, I'm guessing... fadeout only, or ever fadein?
-            rw.RwInt32(ref this.UNUSED_INT32[2]);
-            for (int i=0; i<this.UNUSED_INT32.Length; i++)
-                Trace.Assert(this.UNUSED_INT32[i] == 0, $"Unexpected nonzero value ({this.UNUSED_INT32[i]}) in reserve variable.");
+
+            rw.RwObj(ref this.UNUSED_UINT32[2], args);
         }
     }
 }

--- a/src/lib/FileIO/Serialization/Targets/Reader.cs
+++ b/src/lib/FileIO/Serialization/Targets/Reader.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+//using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
@@ -111,12 +111,8 @@ namespace Serialization
         }
         public void RwObjs<T>(ref T[] objs, int count, Dictionary<string, object> args = null) where T : ISerializable 
         {
-             objs = new T[count];
              for (int i=0; i < count; ++i)
-             {
-                objs[i] = (T) typeof(T).GetConstructors().First().Invoke([]);
                 this.RwObj(objs[i], args);
-             }
         }
 
         // Stream Manipulation
@@ -164,7 +160,8 @@ namespace Serialization
             int skiplength = (int)IBaseBinaryTarget.GetAlignment(position, alignment);
             var buf = this.bytestream.ReadBytes(skiplength);
             foreach (var v in buf)
-                Trace.Assert(v == 0x00, "Expected alignment buffer to be 0x00");
+                if (v != 0x00)
+                    throw new Exception("Expected alignment buffer to be 0x00");
         }
 
         public bool IsEOF()
@@ -174,7 +171,8 @@ namespace Serialization
 
         public void AssertEOF()
         {
-            Trace.Assert(this.IsEOF(), "Finished reading the stream before EOF was reached");
+            if (!this.IsEOF())
+                throw new Exception("Finished reading the stream before EOF was reached");
         }
     }
 }

--- a/src/lib/ProjectManager.cs
+++ b/src/lib/ProjectManager.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 
 namespace EVTUI;
@@ -152,7 +151,8 @@ public class ProjectManager
     {
         lock (this.UserData)
         {
-            Trace.Assert(projInd >= 0 && projInd < this.UserData.Projects.Count && this.UserData.Projects.Count > 0, "User project data is corrupted.");
+            if (projInd < 0 || projInd >= this.UserData.Projects.Count || this.UserData.Projects.Count <= 0)
+                throw new Exception("User project data is corrupted.");
 
             if (projInd > 0)
             {
@@ -176,7 +176,8 @@ public class ProjectManager
                     break;
                 }
 
-            Trace.Assert(!(this.ActiveGame is null) && !(this.ActiveProject is null), "Game specified for project doesn't exist.");
+            if (this.ActiveGame is null || this.ActiveProject is null)
+                throw new Exception("Game specified for project doesn't exist.");
 
             this.ModdedFileDir = this.ActiveProject.Mod.Path;
             if (this.HasFramework("P5REssentials"))
@@ -205,7 +206,8 @@ public class ProjectManager
     {
         lock (this.UserData)
         {
-            Trace.Assert(gameInd >= 0 && gameInd < this.UserData.Games.Count && this.UserData.Games.Count > 0, "User game path data is corrupted.");
+            if (gameInd < 0 || gameInd >= this.UserData.Games.Count || this.UserData.Games.Count <= 0)
+                throw new Exception("User game path data is corrupted.");
 
             if (gameInd > 0)
             {

--- a/src/lib/Rendering/SceneManager.cs
+++ b/src/lib/Rendering/SceneManager.cs
@@ -294,10 +294,10 @@ public class SceneManager
         switch(errorcode)
         {
             case 0x500:
-                Console.WriteLine("OpenGLError: Invalid Enum");
+                Trace.TraceError("OpenGLError: Invalid Enum");
                 break;
             default:
-                Console.WriteLine("OpenGLError Code: 0x" + String.Format("{0:X}", errorcode));
+                Trace.TraceError("OpenGLError Code: 0x" + String.Format("{0:X}", errorcode));
                 break;
         }
     }

--- a/src/lib/ScriptManager.cs
+++ b/src/lib/ScriptManager.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -162,7 +163,7 @@ public class ScriptManager
                                     }
                                     messageCues.Add(node.FunctionArguments[3], new MessageCue(speakerName, turnName, indWithinTurn+1));
                                 }
-                            } catch {}
+                            } catch (Exception ex) { Trace.TraceError(ex.ToString()); }
                         }
             }
             return eventCues;
@@ -451,6 +452,7 @@ public class ScriptManager
         }
         catch (Exception ex)
         {
+            Trace.TraceError(ex.ToString());
             this.ScriptErrors["BMD"][fileBase] = ex.ToString();
         }
     }
@@ -476,6 +478,7 @@ public class ScriptManager
         }
         catch (Exception ex)
         {
+            Trace.TraceError(ex.ToString());
             listener.Text += ex.ToString();
         }
         return listener.Text;
@@ -507,6 +510,7 @@ public class ScriptManager
         }
         catch (Exception ex)
         {
+            Trace.TraceError(ex.ToString());
             listener.Text += ex.ToString();
         }
         this.ScriptErrors["BF"][fileBase] = listener.Text;
@@ -539,6 +543,7 @@ public class ScriptManager
         }
         catch (Exception ex)
         {
+            Trace.TraceError(ex.ToString());
             listener.Text += ex.ToString();
         }
         Directory.SetCurrentDirectory(oldWorkingDir);
@@ -736,8 +741,9 @@ public class ScriptManager
                     else
                         encoded += this.EnCharLookup[(high, unencoded.Dequeue())];
                 }
-                catch (KeyNotFoundException)
+                catch (KeyNotFoundException ex)
                 {
+                    Trace.TraceError(ex.ToString());
                     encoded += "*";
                 }
             else if (high != 0)

--- a/src/lib/Utils.cs
+++ b/src/lib/Utils.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Security.Cryptography;
 using System.Text;
 
@@ -15,5 +16,15 @@ public static class Utils
                 sb.Append($"{b:X2}");
         }
         return sb.ToString();
+    }
+
+    public static void CheckBytes(byte[] bytes, byte expectedValue)
+    {
+        foreach (byte actualValue in bytes)
+            if (actualValue != expectedValue)
+            {
+                Trace.TraceWarning($"Expected sequence of bytes with value {expectedValue} but reached a byte with value {actualValue} instead");
+                break;
+            }
     }
 }


### PR DESCRIPTION
Added `UserLog.txt` to AppData directory to track each EVTUI session anew.

## In this PR:
- Pipe all console and error content into the new log file (which gets cleared at the start of each new session)
- Remove `Assert`s and replace them with...
  - ...errors, in the case of Must-Not-Fail issues
  - ...warning traces + byte cleaning, in the case of things that don't necessarily indicate an error on their own (e.g., nonzero reserve bytes)
- Various new `Serializable` implementations to account for the new behavior and centralize/dedupe the related checks

## For a future PR:
Make in-app debugging easier, namely by...
- ...making error-display dialogue boxes scrollable/copyable, and...
- ...allowing the logs to be viewed from the app