### PR TITLE
Remove a cache clear that breaks sounds played when multiple events are open

### DIFF
--- a/src/lib/FileIO/CPKExtract.cs
+++ b/src/lib/FileIO/CPKExtract.cs
@@ -132,9 +132,6 @@ public static class CPKExtract
 
     public static CpkEVTContents? ExtractEVTFiles(List<string> CpkList, string eventId, string OutputFolder, string existingFolder, string decryptionFunctionName)
     {
-        // clear it first!
-        CPKExtract.ClearDirectory(OutputFolder);
-
         var retval = new CpkEVTContents();
         Regex eventPattern = new Regex($"[\\\\/]{eventId}([\\\\/\\.]|_SE)", RegexOptions.IgnoreCase);
         bool evtFound = false;


### PR DESCRIPTION
The CPK extractor code was clearing out the extracted file folder every time it ran, so when one event was opened after another, it would cause crashes if the former event tried to play its event-specific sound files (for example).

Hopefully I was just being overzealous in clearing it out there before and this doesn't break something else. Files still get cleared when the program closes, so we should at least not blow up everyone's hard drives.