### PR TITLE
Miscellaneous QoL improvements

### DIFF
--- a/src/gui/ConfigWindow/ConfigurationPanel/ConfigurationPanel.axaml
+++ b/src/gui/ConfigWindow/ConfigurationPanel/ConfigurationPanel.axaml
@@ -213,6 +213,16 @@
         <StackPanel IsVisible="{Binding AnyRecentProjects}">
           <TextBlock Classes="tabletitle" Text="Recent Projects"/>
           <DataGrid ItemsSource="{Binding ProjectList}" SelectedItem="{Binding ProjectSelection}">
+            <DataGrid.Styles>
+              <Style Selector="DataGridRow">
+                <Setter Property="ContextMenu">
+                  <ContextMenu>
+                    <MenuItem Header="Delete" Click="DeleteProject"/>
+                    <MenuItem Header="Configure" IsEnabled="false"/>
+                  </ContextMenu>
+                </Setter>
+              </Style>
+            </DataGrid.Styles>
             <DataGrid.Columns>
               <DataGridTextColumn Header="Project Name" Binding="{Binding Name}" IsReadOnly="False"/>
               <DataGridTextColumn Header="Notes" Binding="{Binding Notes}" IsReadOnly="False"/>

--- a/src/gui/ConfigWindow/ConfigurationPanel/ConfigurationPanel.axaml.cs
+++ b/src/gui/ConfigWindow/ConfigurationPanel/ConfigurationPanel.axaml.cs
@@ -3,8 +3,10 @@ using System.Threading.Tasks;
 
 using ReactiveUI;
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Interactivity;
+using Avalonia.LogicalTree;
 using Avalonia.ReactiveUI;
 
 using EVTUI.ViewModels;
@@ -126,6 +128,25 @@ public partial class ConfigurationPanel : ReactiveUserControl<ConfigurationPanel
         }
         else
             await Utils.RaiseModal(this.topLevel, retTuple.Message);
+    }
+
+    public async void DeleteProject(object sender, RoutedEventArgs e)
+    {
+        DisplayableProject project = (DisplayableProject)((DataGridRow)LogicalExtensions.GetLogicalParent(
+            (Border)LogicalExtensions.GetLogicalParent(
+                (DataGridFrozenGrid)LogicalExtensions.GetLogicalParent(
+                    (DataGridCellsPresenter)LogicalExtensions.GetLogicalParent(
+                        (DataGridCell)LogicalExtensions.GetLogicalParent(
+                            (Control)(((Popup)LogicalExtensions.GetLogicalParent(
+                                (ContextMenu)LogicalExtensions.GetLogicalParent(
+                                    (MenuItem)sender))).PlacementTarget))))))).DataContext;
+        int? check = await Utils.RaiseDoubleCheck(this.topLevel, $"Are you sure you want to delete the project \"{project.Name}\"?", "Yes", "No");
+        if (check == 0)
+        {
+            var retTuple = ViewModel!.TryDeleteProject(project);
+            if (retTuple.Status != 0)
+                await Utils.RaiseModal(this.topLevel, retTuple.Message);
+        }
     }
 
     //////////////////////////////////

--- a/src/gui/EditorWindow/TimelinePanel/TimelinePanel.axaml
+++ b/src/gui/EditorWindow/TimelinePanel/TimelinePanel.axaml
@@ -1794,12 +1794,6 @@
       </ScrollViewer>
       <ScrollViewer Name="Scrolly" HorizontalScrollBarVisibility="Visible" VerticalScrollBarVisibility="Disabled" Margin="153,37,16,0" Offset="{Binding $parent[views:TimelinePanel].HPos, Mode=TwoWay}" AllowAutoHide="false">
         <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Hidden" Offset="{Binding $parent[views:TimelinePanel].VPos, Mode=TwoWay}" Margin="0,0,0,16" PointerPressed="LogPosition">
-          <ScrollViewer.ContextMenu>
-            <ContextMenu IsEnabled="{Binding !$parent[views:TimelinePanel]((vm:TimelinePanelViewModel)DataContext).Config.ReadOnly}">
-              <MenuItem Header="New" Click="OpenModal" />
-              <MenuItem Header="Paste" Click="PasteCommand" IsEnabled="{Binding $parent[views:TimelinePanel]((vm:TimelinePanelViewModel)DataContext).SharedClipboard.HasCopiedCommand}" />
-            </ContextMenu>
-          </ScrollViewer.ContextMenu> 
           <ItemsControl ItemsSource="{Binding Categories}" VerticalAlignment="Stretch">
             <ItemsControl.ItemsPanel>
               <ItemsPanelTemplate>
@@ -1810,7 +1804,13 @@
               <DataTemplate>
                 <ItemsControl ItemsSource="{Binding Commands}" MinHeight="40"
                  Classes.show="{Binding IsOpen}"
-                 Classes.hide="{Binding !IsOpen}">
+                 Classes.hide="{Binding !IsOpen}" Background="Transparent">
+                  <ItemsControl.ContextMenu>
+                    <ContextMenu IsEnabled="{Binding !$parent[views:TimelinePanel]((vm:TimelinePanelViewModel)DataContext).Config.ReadOnly}">
+                      <MenuItem Header="New" Click="OpenModal" />
+                      <MenuItem Header="Paste" Click="PasteCommand" IsEnabled="{Binding $parent[views:TimelinePanel]((vm:TimelinePanelViewModel)DataContext).SharedClipboard.HasCopiedCommand}" />
+                    </ContextMenu>
+                  </ItemsControl.ContextMenu> 
                   <ItemsControl.ItemsPanel>
                     <ItemsPanelTemplate>
                       <Canvas MinHeight="40" Height="{c:Binding (IsOpen) ? 60*MaxInOneFrame + 20 : 40}" Width="{c:Binding 85*FrameCount - 5}" Classes.open="{Binding IsOpen}" Classes.closed="{Binding !IsOpen}" HorizontalAlignment="Left"/>

--- a/src/gui/EditorWindow/TimelinePanel/TimelinePanel.axaml.cs
+++ b/src/gui/EditorWindow/TimelinePanel/TimelinePanel.axaml.cs
@@ -167,6 +167,11 @@ public partial class TimelinePanel : ReactiveUserControl<TimelinePanelViewModel>
 
     public void OpenModal(object sender, RoutedEventArgs e)
     {
+        Category category = (Category)(((ItemsControl)LogicalExtensions.GetLogicalParent(
+            (Control)(((Popup)LogicalExtensions.GetLogicalParent(
+                (ContextMenu)LogicalExtensions.GetLogicalParent(
+                    (MenuItem)sender))).PlacementTarget))).DataContext);
+        ViewModel!.SetAddableCodes(category);
         this.ModalIsOpen = true;
     }
 

--- a/src/gui/EditorWindow/TimelinePanel/TimelinePanelViewModel.cs
+++ b/src/gui/EditorWindow/TimelinePanel/TimelinePanelViewModel.cs
@@ -196,7 +196,7 @@ public class Timeline : ReactiveObject
 
     public static int CodeToCategory(string code, bool isAudio)
     {
-        if (isAudio)
+        if (isAudio || code == "Snd_" || code == "SBE_" || code == "SBEA")
             return 10;
         int catInd = 14;
         if (code == "AlEf" || code == "SFlt")
@@ -503,7 +503,7 @@ public class TimelinePanelViewModel : ViewModelBase
     public Timeline TimelineContent { get; set; }
     public dynamic ActiveCommand { get; set; }
 
-    public List<string> AddableCodes { get => this.Config.EventManager.AddableCodes; }
+    public ObservableCollection<string> AddableCodes { get; set; } = new ObservableCollection<string>();
 
     ////////////////////////////
     // *** PUBLIC METHODS *** //
@@ -513,6 +513,14 @@ public class TimelinePanelViewModel : ViewModelBase
         this.Config          = dataManager;
         this.TimelineContent = new Timeline(dataManager);
         this.SharedClipboard = clipboard;
+    }
+
+	public void SetAddableCodes(Category category)
+    {
+        this.AddableCodes.Clear();
+        foreach (string code in this.Config.EventManager.AddableCodes)
+            if (Timeline.CodeToCategory(code, false) + 1 == category.Index)
+                this.AddableCodes.Add(code);
     }
 
     public void SetActiveCommand(CommandPointer cmd)

--- a/src/gui/MainWindow/LandingPage/LandingPage.axaml.cs
+++ b/src/gui/MainWindow/LandingPage/LandingPage.axaml.cs
@@ -61,7 +61,7 @@ public partial class LandingPage : ReactiveUserControl<LandingPageViewModel>
         while (true)
         {
             User userData = ((LandingPageViewModel)DataContext).UserData;
-            DataManager config = new DataManager(userData);
+            DataManager config = new DataManager(userData, this.openStuff);
 
             ConfigWindowViewModel configWindowVM   = new ConfigWindowViewModel(
                 config, configtype);

--- a/src/gui/MainWindow/LandingPage/LandingPageViewModel.cs
+++ b/src/gui/MainWindow/LandingPage/LandingPageViewModel.cs
@@ -7,7 +7,7 @@ public class Clipboard
     // TODO: split this into different types of things you can copy
     // (once there are multiple such things)
 
-    public CommandPointer          CopiedCommand  { get; set; }
+    public CommandPointer         CopiedCommand  { get; set; }
     public TimelinePanelViewModel SourceVM       { get; set; }
 
     public bool HasCopiedCommand { get; set; } = false;

--- a/src/gui/Utilities/MessageBox.cs
+++ b/src/gui/Utilities/MessageBox.cs
@@ -6,8 +6,6 @@ namespace EVTUI.Views;
 public partial class Utils
 {
 
-    // If we need to pop boxes like this from multiple places, we should add this to
-    // a View base class or something.
     public static async Task<int> RaiseModal(Window tl, string text)
     {
         Window sampleWindow =
@@ -27,4 +25,22 @@ public partial class Utils
             return (int)res;
     }
 
+    public static async Task<int> RaiseDoubleCheck(Window tl, string mainMsg="Are you sure?", string yesMsg="Yes", string noMsg="No")
+    {
+        Window sampleWindow =
+            new Window 
+            { 
+                SizeToContent = SizeToContent.WidthAndHeight,
+                WindowStartupLocation = WindowStartupLocation.CenterOwner
+            };
+        sampleWindow.Content = new SafetyBox(mainMsg, yesMsg, noMsg);
+
+        // Launch window and get a return code to distinguish how the window
+        // was closed.
+        int? res = await sampleWindow.ShowDialog<int?>(tl);
+        if (res is null)
+            return 1;
+        else
+            return (int)res;
+    }
 }

--- a/src/gui/Utilities/SafetyBox.axaml
+++ b/src/gui/Utilities/SafetyBox.axaml
@@ -1,0 +1,18 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="EVTUI.Views.SafetyBox">
+  <StackPanel Margin="20" VerticalAlignment="Center">
+    <TextBlock Name="ModalText" HorizontalAlignment="Center" Margin="20"/>
+    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+      <Button Name="YesButton" Click="YesHandler" Background="{DynamicResource SystemAccentColor}" HorizontalAlignment="Center" Padding="10" Margin="20" Focusable="True">
+        <TextBlock Name="YesText"/>
+      </Button>
+      <Button Name="NoButton" Click="NoHandler" HorizontalAlignment="Center" Padding="10" Margin="20" Focusable="True">
+        <TextBlock Name="NoText"/>
+      </Button>
+    </StackPanel>
+  </StackPanel>
+</UserControl>

--- a/src/gui/Utilities/SafetyBox.axaml.cs
+++ b/src/gui/Utilities/SafetyBox.axaml.cs
@@ -1,0 +1,47 @@
+using System;
+
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+
+namespace EVTUI.Views;
+
+public partial class SafetyBox : UserControl
+{
+    public string MainMsg = "Are you sure?";
+    public string YesMsg = "Yes";
+    public string NoMsg = "No";
+
+    public SafetyBox(string mainMsg, string yesMsg, string noMsg)
+    {
+        this.Initialized += this.OnInitialized;
+        InitializeComponent();
+        this.MainMsg = mainMsg;
+        this.YesMsg = yesMsg;
+        this.NoMsg = noMsg;
+    }
+
+    public void OnInitialized(object? sender, EventArgs e)
+    {
+        this.ModalText.Text = this.MainMsg;
+        this.YesText.Text = this.YesMsg;
+        this.NoText.Text = this.NoMsg;
+        this.NoButton.AttachedToVisualTree += (s, e) => this.NoButton.Focus();
+    }
+
+    public void YesHandler(object sender, RoutedEventArgs args)
+    {
+        var tl = TopLevel.GetTopLevel(this);
+        if (tl is null) throw new NullReferenceException();
+        var topLevel = (Window)tl;
+        topLevel.Close(0);
+    }
+
+    public void NoHandler(object sender, RoutedEventArgs args)
+    {
+        var tl = TopLevel.GetTopLevel(this);
+        if (tl is null) throw new NullReferenceException();
+        var topLevel = (Window)tl;
+        topLevel.Close(null);
+    }
+}

--- a/src/lib/DataManager.cs
+++ b/src/lib/DataManager.cs
@@ -40,19 +40,31 @@ public class DataManager
     public List<Project>      AllProjects   { get => this.ProjectManager.UserData.Projects; }
     public List<GameSettings> AllGames      { get => this.ProjectManager.UserData.Games;    }
 
+    private HashSet<(string GamePath, string? ModPath, int MajorId, int MinorId)> OpenStuff;
+
     ////////////////////////////
     // *** PUBLIC METHODS *** //
     ////////////////////////////
-    public DataManager(User userData)
+    public DataManager(User userData, HashSet<(string GamePath, string? ModPath, int MajorId, int MinorId)> openStuff)
     {
         if (!Directory.Exists(this.VanillaExtractionPath))
             Directory.CreateDirectory(this.VanillaExtractionPath);
+
+        this.OpenStuff = openStuff;
 
         this.ProjectManager = new ProjectManager(userData);
         this.EventManager   = new EventManager();
         this.ScriptManager  = new ScriptManager();
         this.AudioManager   = new AudioManager();
         this.CpkList        = new List<string>();
+    }
+
+    public bool CheckIfProjOpen(string modPath)
+    {
+        foreach (var openThing in this.OpenStuff)
+            if (openThing.ModPath == modPath)
+                return true;
+        return false;
     }
 
     public void Reset()

--- a/src/lib/EventManager.cs
+++ b/src/lib/EventManager.cs
@@ -75,6 +75,12 @@ public class EventManager
         else
             this.SerialEventSounds.Read(this.EcsPath);
 
+        // cheap way of putting en.cpk before base.cpk and modded files before vanilla files, lolllll
+        // i'll do it properly eventually, maybe
+        cpkEVTContents.Value.acbPaths.Reverse();
+        cpkEVTContents.Value.bfPaths.Reverse();
+        cpkEVTContents.Value.bmdPaths.Reverse();
+
         // the DataManager will pass these to the AudioManager
         this.AcwbPaths = new List<(string ACB, string? AWB)>();
         foreach (string acbPath in cpkEVTContents.Value.acbPaths)

--- a/src/lib/FileIO/CPKExtract.cs
+++ b/src/lib/FileIO/CPKExtract.cs
@@ -206,6 +206,12 @@ public static class CPKExtract
             ArrayRental.Reset();
         });
 
+        // sort them so they can be reverse sorted later in the EventManager
+        // awbPaths is only ever searched in the order of acbPaths so there's no point in sorting it
+        retval.acbPaths.Sort();
+        retval.bfPaths.Sort();
+        retval.bmdPaths.Sort();
+
         // overwrite paths to extracted (vanilla) files with files from mod
         Parallel.ForEach(Directory.GetFiles(existingFolder, "*.*", SearchOption.AllDirectories), ModPath => { maybePickFile(ModPath, true); });
 

--- a/src/lib/FileIO/UserCache.cs
+++ b/src/lib/FileIO/UserCache.cs
@@ -38,8 +38,8 @@ Preferences: {}";
     ////////////////////////////
     public static User InitializeOrLoadUser()
     {
-        Console.SetOut(UserLogWriter);
-        Console.SetError(UserLogWriter);
+        //Console.SetOut(UserLogWriter);
+        //Console.SetError(UserLogWriter);
 
         Trace.Listeners.Add(Logger);
         Trace.AutoFlush = true;

--- a/src/lib/ProjectManager.cs
+++ b/src/lib/ProjectManager.cs
@@ -202,6 +202,18 @@ public class ProjectManager
         }
     }
 
+    public bool DeleteProject(int projInd)
+    {
+        lock (this.UserData)
+        {
+            if (projInd < 0 || projInd >= this.UserData.Projects.Count || this.UserData.Projects.Count <= 0)
+                return false;
+            this.UserData.Projects.RemoveAt(projInd);
+            this.SaveUserCache();
+        }
+        return true;
+    }
+
     public void LoadGameReadOnly(int gameInd)
     {
         lock (this.UserData)

--- a/src/lib/ScriptManager.cs
+++ b/src/lib/ScriptManager.cs
@@ -313,7 +313,11 @@ public class ScriptManager
         // TODO: this is dumb, fix this with the file management PR
         foreach (List<string> pathList in new[] { bmdPaths, bfPaths })
             if (!(pathList is null))
-                for (int i = 0; i < pathList.Count; i++)
+                //for (int i = 0; i < pathList.Count; i++)
+                // oh god this is bad and stupid. bandaid solution to go with the sort + reverse thing for the files
+                // otherwise, if the vanilla and mod cpk names are the same and emulator is off, it gets ugly.
+                // TODO TODO TODO oh god TODO
+                for (int i = pathList.Count-1; i >= 0; i--)
                 {
                     string workingPath = null;
                     if (pathList[i].StartsWith(baseDir))


### PR DESCRIPTION
By popular demand! The first of many such PRs, I suspect.

## In this PR:
- "Add New Command" modal now only shows command options from the category in which the user right-clicked for the menu (as opposed to the huge list of all commands)
- Band-aid solution for script load order (so it should be consistent + modded ones should take priority for showing up in the timeline)
- Projects can be deleted by right-clicking the entries in the "Open Project" menu

## In a future PR:
- Non-Band-aid solution for script load order... like, actual improved file management...
- More flexible navigation of the config/event-opening window to be able to move back and forth between steps (and maybe also leave that window open even once the event has been chosen...?)