### PR TITLE
Fix issue with grabbing incorrect mod files + allow LE BMDs

### DIFF
--- a/src/lib/FileIO/CPKExtract.cs
+++ b/src/lib/FileIO/CPKExtract.cs
@@ -79,6 +79,7 @@ public static class CPKExtract
         string filePatternString = String.Join(delim, prefix);
         if (!(suffix is null))
             filePatternString += delim + suffix;
+        filePatternString += "$";
         Regex filePattern = new Regex(filePatternString, RegexOptions.IgnoreCase);
         if (!String.IsNullOrEmpty(ExistingFolder))
             foreach (var ModPath in Directory.GetFiles(ExistingFolder, "*.*", SearchOption.AllDirectories))


### PR DESCRIPTION
A lack of `$` at the end of the regex search for mod files meant `.bmd.msg`s were getting grabbed instead of `.bmd`s... RIP.

Also, custom BMD parsing can now accommodate Version1(LittleEndian) :tada: