### PR TITLE
Backlog of minor errors and feature requests

### DIFF
--- a/src/gui/EditorWindow/Common/CommandViewModels/FdS_.cs
+++ b/src/gui/EditorWindow/Common/CommandViewModels/FdS_.cs
@@ -13,8 +13,8 @@ public class FdS_ : Generic
     {
         this.LongName = "Fade (Simple)";
 
-        this.FadeType = new StringSelectionField("Fade Type", this.Editable, FdS_.BasicFadeTypes.Backward[this.CommandData.FadeType], FdS_.BasicFadeTypes.Keys);
-        this.WhenAnyValue(_ => _.FadeType.Choice).Subscribe(_ => this.CommandData.FadeType = FdS_.BasicFadeTypes.Forward[this.FadeType.Choice]);
+        this.FadeType = new StringSelectionField("Fade Type", this.Editable, FdS_.BasicFadeTypes.BackwardGet(this.CommandData.FadeType, "None"), FdS_.BasicFadeTypes.Keys);
+        this.WhenAnyValue(_ => _.FadeType.Choice).Subscribe(_ => this.CommandData.FadeType = FdS_.BasicFadeTypes.ForwardGet(this.FadeType.Choice, 0));
         this.UnkBool = new BoolChoiceField("Unknown", this.Editable, this.CommandData.UnkBool != 0);
         this.WhenAnyValue(_ => _.UnkBool.Value).Subscribe(_ => this.CommandData.UnkBool = Convert.ToByte(this.UnkBool.Value));
     }

--- a/src/gui/EditorWindow/Common/TimelineViewModel.cs
+++ b/src/gui/EditorWindow/Common/TimelineViewModel.cs
@@ -19,6 +19,7 @@ public class TimelineViewModel : ReactiveObject
     public NumEntryField        MinorID { get; set; }
     public StringSelectionField Rank    { get; set; }
     public NumEntryField        Level   { get; set; }
+    public StringSelectionField Endianness { get; set; }
     // flags
     public BoolChoiceField StartingFrameEnabled        { get; set; }
     public BoolChoiceField UnkFlag1                    { get; set; }
@@ -44,6 +45,12 @@ public class TimelineViewModel : ReactiveObject
         D    = 5
     }
 
+    public enum Endiannesses : byte
+    {
+        Little = 0,
+        Big    = 1
+    }
+
     public TimelineViewModel(DataManager dataManager)
     {
         this.subscriptions = new List<IDisposable>();
@@ -56,11 +63,13 @@ public class TimelineViewModel : ReactiveObject
         this.MinorID = new NumEntryField("Minor ID", !dataManager.ReadOnly, evt.MinorId, 0, 999, 1);
         this.Rank = new StringSelectionField("Rank", !dataManager.ReadOnly, Enum.GetName(typeof(Ranks), evt.Rank), new List<string>(Enum.GetNames(typeof(Ranks))));
         this.Level = new NumEntryField("Level", !dataManager.ReadOnly, evt.Level, 0, 3, 1);
+        this.Endianness = new StringSelectionField("Endianness", !dataManager.ReadOnly, Enum.GetName(typeof(Endiannesses), evt.Endianness), new List<string>(Enum.GetNames(typeof(Endiannesses))));
 
         this.subscriptions.Add(this.WhenAnyValue(x => x.MajorID.Value).Subscribe(x => evt.MajorId = (short)x));
         this.subscriptions.Add(this.WhenAnyValue(x => x.MinorID.Value).Subscribe(x => evt.MinorId = (short)x));
         this.subscriptions.Add(this.WhenAnyValue(x => x.Rank.Choice).Subscribe(x => evt.Rank = (byte)Enum.Parse(typeof(Ranks), x)));
         this.subscriptions.Add(this.WhenAnyValue(x => x.Level.Value).Subscribe(x => evt.Level = (byte)x));
+        this.subscriptions.Add(this.WhenAnyValue(x => x.Endianness.Choice).Subscribe(x => evt.Endianness = (byte)Enum.Parse(typeof(Endiannesses), x)));
 
         // cinemascope
         this.CinemascopeEnabled = new BoolChoiceField("Enable Cinemascope", !dataManager.ReadOnly, evt.Flags[8]);

--- a/src/gui/EditorWindow/ScriptPanel/ScriptPanelViewModel.cs
+++ b/src/gui/EditorWindow/ScriptPanel/ScriptPanelViewModel.cs
@@ -120,7 +120,7 @@ public class ScriptPanelViewModel : ViewModelBase
         this.EmbedBMD = new BoolChoiceField("Use custom BMD path?", this.Editable, evt.Flags[12]);
         this.BMDPath = new StringEntryField("Custom BMD path", this.Editable, (evt.EventBmdPath is null) ? $"event_data/message/e{(100*(evt.MajorId/100)):000}/e{evt.MajorId:000}_{evt.MinorId:000}.bmd" : evt.EventBmdPath.Replace("\0", ""), 48);
         this.EmbedBF = new BoolChoiceField("Use custom BF path?", this.Editable, evt.Flags[14]);
-        this.BFPath = new StringEntryField("Custom BF path", this.Editable, (evt.EventBfPath is null) ? $"event_data/message/e{(100*(evt.MajorId/100)):000}/e{evt.MajorId:000}_{evt.MinorId:000}.bf" : evt.EventBfPath.Replace("\0", ""), 48);
+        this.BFPath = new StringEntryField("Custom BF path", this.Editable, (evt.EventBfPath is null) ? $"event_data/script/e{(100*(evt.MajorId/100)):000}/e{evt.MajorId:000}_{evt.MinorId:000}.bf" : evt.EventBfPath.Replace("\0", ""), 48);
         this.InitScriptEnabled = new BoolChoiceField("Enable Init Script", this.Editable, evt.Flags[1]);
         this.InitScriptIndex = new NumEntryField("Init Script Index", this.Editable, (int)evt.InitScriptIndex, 0, 255, 1);
 

--- a/src/gui/EditorWindow/TimelinePanel/TimelinePanel.axaml
+++ b/src/gui/EditorWindow/TimelinePanel/TimelinePanel.axaml
@@ -1733,6 +1733,7 @@
                       <ContentControl Content="{Binding MinorID}"/>
                       <ContentControl Content="{Binding Rank}"/>
                       <ContentControl Content="{Binding Level}"/>
+                      <ContentControl Content="{Binding Endianness}"/>
                     </StackPanel>
                   </Expander>
                   <Expander Header="Environment">

--- a/src/lib/ScriptManager.cs
+++ b/src/lib/ScriptManager.cs
@@ -133,6 +133,8 @@ public class ScriptManager
                     locale = eventCues.JpCues;
                 else
                     locale = eventCues.EnCues;
+                try
+                {
                 foreach (Turn turn in this.BMDFiles[key].Turns)
                     for (int indWithinTurn=0; indWithinTurn<turn.Elems.Length; indWithinTurn++)
                         foreach (Node node in this.Parse(turn.Elems[indWithinTurn], isJP))
@@ -172,6 +174,8 @@ public class ScriptManager
                                 }
                             } catch (Exception ex) { Trace.TraceError(ex.ToString()); }
                         }
+                // seems like sometimes the BMDFile can be null... or the Turns can be null? unclear
+                } catch (Exception ex) { Trace.TraceError(ex.ToString()); }
             }
             return eventCues;
         }

--- a/src/lib/Utils.cs
+++ b/src/lib/Utils.cs
@@ -104,6 +104,22 @@ public class BiDict<TKey, TValue>
         this.Backward[value] = key;
     }
 
+    public TValue? ForwardGet(TKey key, TValue fallback = default(TValue))
+    {
+        if (this.Forward.ContainsKey(key))
+            return this.Forward[key];
+        else
+            return fallback;
+    }
+
+    public TKey? BackwardGet(TValue key, TKey fallback = default(TKey))
+    {
+        if (this.Backward.ContainsKey(key))
+            return this.Backward[key];
+        else
+            return fallback;
+    }
+
     public List<TKey> Keys { get => this.Forward.Keys.ToList(); }
 
     public List<TValue> Values { get => this.Backward.Keys.ToList(); }


### PR DESCRIPTION
Miscellaneous requests for fixes from the Discord over the last few months!

## In this PR
- Made a "safe" option for getting keys/values from BiDict; currently applied to `FdS_`, since Raven was having issues with key errors on EvtTool-edited EVTs with that command (seems to have the values in the wrong endianness or something)
- Added EVT Endianness to the "..."-button settings in the Timeline tab; should work for converting big-endian EVTs to little-endian EVTs (and vice versa)
- Fixed script path default in script panel (it was pointing to `/message/` instead of `/script/`)
- Added an additional try/catch wrapper around `EventCues`, since Power was getting a null reference error there; not an elegant solution, but also not an elegant method (needs to be reworked/moved/replaced)

## For a future PR
- Apply the "safe" BiDict indexing everywhere, maybe... I can't be bothered for now, and also, if it ain't broke...