### PR TITLE
Add endianness toggle for ECS

### DIFF
--- a/src/gui/EditorWindow/Common/TimelineViewModel.cs
+++ b/src/gui/EditorWindow/Common/TimelineViewModel.cs
@@ -19,7 +19,9 @@ public class TimelineViewModel : ReactiveObject
     public NumEntryField        MinorID { get; set; }
     public StringSelectionField Rank    { get; set; }
     public NumEntryField        Level   { get; set; }
-    public StringSelectionField Endianness { get; set; }
+    // endianness
+    public StringSelectionField EVTEndianness { get; set; }
+    public StringSelectionField ECSEndianness { get; set; }
     // flags
     public BoolChoiceField StartingFrameEnabled        { get; set; }
     public BoolChoiceField UnkFlag1                    { get; set; }
@@ -55,6 +57,7 @@ public class TimelineViewModel : ReactiveObject
     {
         this.subscriptions = new List<IDisposable>();
         EVT evt = (EVT)dataManager.EventManager.SerialEvent;
+        ECS ecs = (ECS)dataManager.EventManager.SerialEventSounds;
 
         // from header
 
@@ -63,13 +66,18 @@ public class TimelineViewModel : ReactiveObject
         this.MinorID = new NumEntryField("Minor ID", !dataManager.ReadOnly, evt.MinorId, 0, 999, 1);
         this.Rank = new StringSelectionField("Rank", !dataManager.ReadOnly, Enum.GetName(typeof(Ranks), evt.Rank), new List<string>(Enum.GetNames(typeof(Ranks))));
         this.Level = new NumEntryField("Level", !dataManager.ReadOnly, evt.Level, 0, 3, 1);
-        this.Endianness = new StringSelectionField("Endianness", !dataManager.ReadOnly, Enum.GetName(typeof(Endiannesses), evt.Endianness), new List<string>(Enum.GetNames(typeof(Endiannesses))));
 
         this.subscriptions.Add(this.WhenAnyValue(x => x.MajorID.Value).Subscribe(x => evt.MajorId = (short)x));
         this.subscriptions.Add(this.WhenAnyValue(x => x.MinorID.Value).Subscribe(x => evt.MinorId = (short)x));
         this.subscriptions.Add(this.WhenAnyValue(x => x.Rank.Choice).Subscribe(x => evt.Rank = (byte)Enum.Parse(typeof(Ranks), x)));
         this.subscriptions.Add(this.WhenAnyValue(x => x.Level.Value).Subscribe(x => evt.Level = (byte)x));
-        this.subscriptions.Add(this.WhenAnyValue(x => x.Endianness.Choice).Subscribe(x => evt.Endianness = (byte)Enum.Parse(typeof(Endiannesses), x)));
+
+        // endianness
+        this.EVTEndianness = new StringSelectionField("EVT", !dataManager.ReadOnly, Enum.GetName(typeof(Endiannesses), evt.Endianness), new List<string>(Enum.GetNames(typeof(Endiannesses))));
+        this.ECSEndianness = new StringSelectionField("ECS", !dataManager.ReadOnly, Enum.GetName(typeof(Endiannesses), Convert.ToByte(!ecs.IsLittleEndian)), new List<string>(Enum.GetNames(typeof(Endiannesses))));
+
+        this.subscriptions.Add(this.WhenAnyValue(x => x.EVTEndianness.Choice).Subscribe(x => evt.Endianness = (byte)Enum.Parse(typeof(Endiannesses), x)));
+        this.subscriptions.Add(this.WhenAnyValue(x => x.ECSEndianness.Choice).Subscribe(x => ecs.IsLittleEndian = ((byte)Enum.Parse(typeof(Endiannesses), x) == 0)));
 
         // cinemascope
         this.CinemascopeEnabled = new BoolChoiceField("Enable Cinemascope", !dataManager.ReadOnly, evt.Flags[8]);

--- a/src/gui/EditorWindow/TimelinePanel/TimelinePanel.axaml
+++ b/src/gui/EditorWindow/TimelinePanel/TimelinePanel.axaml
@@ -1733,13 +1733,18 @@
                       <ContentControl Content="{Binding MinorID}"/>
                       <ContentControl Content="{Binding Rank}"/>
                       <ContentControl Content="{Binding Level}"/>
-                      <ContentControl Content="{Binding Endianness}"/>
                     </StackPanel>
                   </Expander>
                   <Expander Header="Environment">
                     <StackPanel Classes="form">
                       <ContentControl Content="{Binding InitEnvAssetID}"/>
                       <ContentControl Content="{Binding DebugEnvAssetID}"/>
+                    </StackPanel>
+                  </Expander>
+                  <Expander Header="Endianness">
+                    <StackPanel Classes="form">
+                      <ContentControl Content="{Binding EVTEndianness}"/>
+                      <ContentControl Content="{Binding ECSEndianness}"/>
                     </StackPanel>
                   </Expander>
                   <Expander Header="Other Flags">

--- a/src/lib/EventManager.cs
+++ b/src/lib/EventManager.cs
@@ -17,7 +17,7 @@ public class EventManager
     ///////////////./////////////
     private DataManager config;
     //private EVT? SerialEvent = null;
-    private ECS? SerialEventSounds = null;
+    //private ECS? SerialEventSounds = null;
 
     ////////////////////////////
     // *** PUBLIC MEMBERS *** //
@@ -31,6 +31,7 @@ public class EventManager
     // TODO: re-privatize this...? the Basics and Assets tabs use it...
     // is there a nicer way than having it just be public?
     public EVT? SerialEvent = null;
+    public ECS? SerialEventSounds = null;
 
     ////////////////////////////
     // *** PUBLIC METHODS *** //


### PR DESCRIPTION
Building off of https://github.com/DarkPsydeOfTheMoon/EVTUI/pull/66, where an endianness toggle was added for the EVT. Now a matching one for the ECS!

Could theoretically group the toggle into one that affects both, since they're usually the same, but let's keep it flexible for now, just in case.